### PR TITLE
Feat: 유통기한 만료 시 '기한 만료' 문구 추가

### DIFF
--- a/src/features/home/components/FoodListItem.tsx
+++ b/src/features/home/components/FoodListItem.tsx
@@ -13,6 +13,7 @@ export function FoodListItem({ item }: FoodListItemProps) {
   const statusBgColor = FOOD_STATUS_BG_COLORS[foodStatus];
   const expiryLabel = getExpiryLabel(expirationDate, daysLeft);
   const unitLabel = getUnitLabel(item.quantity.unit);
+  const isExpired = daysLeft < 0;
 
   return (
     <Card
@@ -51,11 +52,11 @@ export function FoodListItem({ item }: FoodListItemProps) {
         <YStack ai="flex-end" gap="$1">
           <View width={45} py="$1" br="$2" bg={`${statusBgColor}`} ai="center">
             <Text color={statusColor} fontWeight="800" fontSize="$3">
-              D-{daysLeft}
+              {isExpired ? "만료" : `D-${daysLeft}`}
             </Text>
           </View>
           <Text fontSize={10} color="$gray9">
-            {expiryLabel}
+            {isExpired ? "기한 만료" : expiryLabel}
           </Text>
         </YStack>
       </XStack>


### PR DESCRIPTION
## 작업 내용

- 유통기한이 만료된 식품들을 '기한 만료' , '만료' 로 표시합니다.

## 연관 이슈

- #27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 식품 목록의 만료 상태 표시 개선. 만료된 항목은 한국어로 "만료", "기한 만료"로 표시됩니다. 만료되지 않은 항목의 기존 표시는 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->