### PR TITLE
Feat: 알림 목록 페이지 구현

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,9 +21,39 @@ import { useReactQueryDevTools } from "@dev-plugins/react-query";
 import { useFonts } from "expo-font";
 import config from "../tamagui.config";
 
+import { useNotificationStore } from "@/features/notification/stores/useNotificationStore";
+import {
+  getMessaging,
+  setBackgroundMessageHandler,
+} from "@react-native-firebase/messaging";
+
 if (__DEV__) {
   require("../ReactotronConfig");
 }
+// 백그라운드일때
+const messaging = getMessaging();
+
+setBackgroundMessageHandler(messaging, async (remoteMessage) => {
+  try {
+    if (remoteMessage.notification) {
+      const targetScreen = remoteMessage.data?.target_screen;
+      const state = useNotificationStore.getState();
+
+      // 스토어가 정상적으로 로드된 경우에만 저장
+      if (state && state.addNotification) {
+        state.addNotification({
+          title: remoteMessage.notification.title || "유통기한 임박",
+          body: remoteMessage.notification.body || "",
+          targetScreen:
+            typeof targetScreen === "string" ? targetScreen : undefined,
+          messageId: remoteMessage.messageId ?? undefined,
+        });
+      }
+    }
+  } catch (error) {
+    console.error("Background Store Error:", error);
+  }
+});
 
 export const unstable_settings = {
   anchor: "(tabs)",
@@ -31,11 +61,15 @@ export const unstable_settings = {
 
 SplashScreen.preventAutoHideAsync().catch(() => {});
 
+let hasShownAnimatedSplash = false;
+
 export default function RootLayout() {
   useReactQueryDevTools(queryClient);
   const isLoaded = useIsAuthLoaded();
   const { hydrate } = useAuthActions();
-  const [animationFinished, setAnimationFinished] = useState(false);
+  const [animationFinished, setAnimationFinished] = useState(
+    hasShownAnimatedSplash,
+  );
   const [fontsLoaded, fontError] = useFonts({
     "GyeonggiBatang-Bold": require("../assets/fonts/GyeonggiBatang-Bold.otf"),
     "GyeonggiTitle-Bold": require("../assets/fonts/GyeonggiTitle-Bold.otf"),
@@ -58,7 +92,10 @@ export default function RootLayout() {
     return (
       <View style={{ flex: 1 }} onLayout={onLayoutRootView}>
         <AnimatedSplashScreen
-          onAnimationFinish={() => setAnimationFinished(true)}
+          onAnimationFinish={() => {
+            hasShownAnimatedSplash = true;
+            setAnimationFinished(true);
+          }}
         />
       </View>
     );

--- a/src/features/notification/components/NotificationItem.tsx
+++ b/src/features/notification/components/NotificationItem.tsx
@@ -1,0 +1,70 @@
+import { formatNotificationTime } from "@/shared/utils/date";
+import { Bell } from "@tamagui/lucide-icons";
+import { useRouter } from "expo-router";
+import React from "react";
+import { Pressable } from "react-native";
+import { Circle, Text, XStack, YStack } from "tamagui";
+import { useNotificationStore } from "../stores/useNotificationStore";
+import type { NotificationItemProps } from "../types";
+
+// 알림 유형에 따른 스타일 (현재는 유통기한)
+const NOTIFICATION_CONFIG = {
+  icon: Bell,
+  color: "$warning",
+  bg: "$warningBackground",
+  label: "유통기한 임박",
+};
+
+export const NotificationItem = ({ item }: { item: NotificationItemProps }) => {
+  const router = useRouter();
+  const markAsRead = useNotificationStore((state) => state.markAsRead);
+  const Icon = NOTIFICATION_CONFIG.icon;
+
+  const handlePress = () => {
+    markAsRead(item.id);
+    if (item.targetScreen === "FOOD_STATUS") {
+      router.push("/(tabs)");
+    }
+  };
+
+  return (
+    <Pressable onPress={handlePress}>
+      <XStack
+        p="$4"
+        backgroundColor="$background"
+        gap="$3"
+        ai="flex-start"
+        opacity={item.isRead ? 0.3 : 1}
+      >
+        <Circle size={40} backgroundColor={NOTIFICATION_CONFIG.bg}>
+          <Icon size={20} color={NOTIFICATION_CONFIG.color} />
+        </Circle>
+
+        <YStack f={1} gap="$1">
+          <XStack jc="space-between" ai="center">
+            <Text
+              fontSize={12}
+              color={NOTIFICATION_CONFIG.color}
+              fontWeight="700"
+            >
+              {NOTIFICATION_CONFIG.label}
+            </Text>
+            <XStack ai="center" gap="$2">
+              <Text fontSize="$3" color="$gray9">
+                {formatNotificationTime(item.createdAt)}
+              </Text>
+              {!item.isRead && <Circle size={6} backgroundColor="$red10" />}
+            </XStack>
+          </XStack>
+
+          <Text fontSize="$3" fontWeight="700" color="$black" numberOfLines={1}>
+            {item.title}
+          </Text>
+          <Text fontSize="$3" color="$gray10" lineHeight={18}>
+            {item.body}
+          </Text>
+        </YStack>
+      </XStack>
+    </Pressable>
+  );
+};

--- a/src/features/notification/screens/NotificationScreen.tsx
+++ b/src/features/notification/screens/NotificationScreen.tsx
@@ -1,16 +1,82 @@
 import { Header } from "@/shared/components/Header/Header";
-import { Text, YStack } from "tamagui";
+import React, { Fragment } from "react";
+import { Alert } from "react-native";
+import { Button, ScrollView, Separator, Text, XStack, YStack } from "tamagui";
+import { NotificationItem } from "../components/NotificationItem";
+import { useNotificationStore } from "../stores/useNotificationStore";
 
 export function NotificationScreen() {
+  const { notifications, markAllAsRead, clearAll } = useNotificationStore();
+  const hasUnreadNotifications = notifications.some(
+    (notification) => !notification.isRead,
+  );
+
+  const handleClearAll = () => {
+    Alert.alert("알림 전체 삭제", "모든 알림을 삭제할까요?", [
+      { text: "취소", style: "cancel" },
+      { text: "삭제", style: "destructive", onPress: clearAll },
+    ]);
+  };
+
   return (
     <YStack f={1} backgroundColor="$background">
       <Header title="알림" showBackButton showNotificationBell={false} />
 
-      <YStack f={1} jc="center" ai="center">
-        <Text fontSize="$6" fontWeight="bold">
-          Notification Screen
-        </Text>
-      </YStack>
+      {notifications.length > 0 && (
+        <XStack
+          px="$4"
+          py="$2"
+          gap="$2"
+          jc="flex-end"
+          ai="center"
+          borderBottomWidth={1}
+          borderColor="$gray3"
+          backgroundColor="$background"
+        >
+          <Button
+            chromeless
+            size="$2"
+            color="$mainText"
+            fontFamily="$baemin"
+            onPress={markAllAsRead}
+            disabled={!hasUnreadNotifications}
+            opacity={hasUnreadNotifications ? 1 : 0.4}
+          >
+            전체 읽음
+          </Button>
+          <Text color="$mainText">|</Text>
+          <Button
+            chromeless
+            size="$2"
+            color="$warning"
+            fontFamily="$baemin"
+            onPress={handleClearAll}
+          >
+            전체 삭제
+          </Button>
+        </XStack>
+      )}
+
+      <ScrollView f={1}>
+        <YStack>
+          {notifications.length > 0 ? (
+            notifications.map((item, index) => (
+              <Fragment key={item.id}>
+                <NotificationItem item={item} />
+                {index < notifications.length - 1 && (
+                  <Separator borderColor="$gray3" />
+                )}
+              </Fragment>
+            ))
+          ) : (
+            <YStack f={1} ai="center" jc="center" mt="$10" px="$4">
+              <Text color="$gray10" fow="500">
+                최근 받은 알림이 없습니다.
+              </Text>
+            </YStack>
+          )}
+        </YStack>
+      </ScrollView>
     </YStack>
   );
 }

--- a/src/features/notification/stores/useNotificationStore.test.ts
+++ b/src/features/notification/stores/useNotificationStore.test.ts
@@ -60,6 +60,25 @@ describe("useNotificationStore 테스트", () => {
     expect(notifications[0].title).toBe("첫 번째");
   });
 
+  it("messageId가 없으면 같은 알림은 중복 추가되지 않아야 한다", () => {
+    const { addNotification } = useNotificationStore.getState();
+
+    addNotification({
+      title: "제목",
+      body: "내용",
+    });
+    addNotification({
+      title: "제목",
+      body: "내용",
+    });
+
+    const notifications = useNotificationStore.getState().notifications;
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].title).toBe("제목");
+    expect(notifications[0].body).toBe("내용");
+  });
+
   it("알림은 최신순으로 유지되며 최대 50개까지만 저장되어야 한다", () => {
     const { addNotification } = useNotificationStore.getState();
 

--- a/src/features/notification/stores/useNotificationStore.test.ts
+++ b/src/features/notification/stores/useNotificationStore.test.ts
@@ -1,0 +1,117 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useNotificationStore } from "./useNotificationStore";
+
+jest.mock("@react-native-async-storage/async-storage", () =>
+  require("@react-native-async-storage/async-storage/jest/async-storage-mock"),
+);
+
+describe("useNotificationStore 테스트", () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await AsyncStorage.clear();
+
+    useNotificationStore.setState({
+      notifications: [],
+      pendingNotificationNavigation: false,
+    });
+  });
+
+  it("addNotification이 새 알림을 추가하고 기본값을 설정해야 한다", () => {
+    const { addNotification } = useNotificationStore.getState();
+
+    addNotification({
+      title: "유통기한 임박",
+      body: "우유가 내일 만료됩니다.",
+      targetScreen: "FOOD_STATUS",
+      messageId: "msg-1",
+    });
+
+    const [notification] = useNotificationStore.getState().notifications;
+
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+    expect(notification).toMatchObject({
+      id: "msg-1",
+      title: "유통기한 임박",
+      body: "우유가 내일 만료됩니다.",
+      targetScreen: "FOOD_STATUS",
+      messageId: "msg-1",
+      isRead: false,
+    });
+    expect(notification.createdAt).toBeTruthy();
+  });
+
+  it("같은 messageId 알림은 중복 추가되지 않아야 한다", () => {
+    const { addNotification } = useNotificationStore.getState();
+
+    addNotification({
+      title: "첫 번째",
+      body: "첫 번째",
+      messageId: "dup-1",
+    });
+    addNotification({
+      title: "두 번째",
+      body: "두 번째",
+      messageId: "dup-1",
+    });
+
+    const notifications = useNotificationStore.getState().notifications;
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].title).toBe("첫 번째");
+  });
+
+  it("알림은 최신순으로 유지되며 최대 50개까지만 저장되어야 한다", () => {
+    const { addNotification } = useNotificationStore.getState();
+
+    for (let index = 0; index < 55; index += 1) {
+      addNotification({
+        title: `알림-${index}`,
+        body: `내용-${index}`,
+        messageId: `id-${index}`,
+      });
+    }
+
+    const notifications = useNotificationStore.getState().notifications;
+
+    expect(notifications).toHaveLength(50);
+    expect(notifications[0].messageId).toBe("id-54");
+    expect(notifications[49].messageId).toBe("id-5");
+  });
+
+  it("markAsRead와 markAllAsRead가 읽음 상태를 올바르게 변경해야 한다", () => {
+    const { addNotification, markAsRead, markAllAsRead } =
+      useNotificationStore.getState();
+
+    addNotification({ title: "A", body: "A", messageId: "read-1" });
+    addNotification({ title: "B", body: "B", messageId: "read-2" });
+
+    markAsRead("read-1");
+
+    let notifications = useNotificationStore.getState().notifications;
+    const first = notifications.find((item) => item.id === "read-1");
+    const second = notifications.find((item) => item.id === "read-2");
+
+    expect(first?.isRead).toBe(true);
+    expect(second?.isRead).toBe(false);
+
+    markAllAsRead();
+
+    notifications = useNotificationStore.getState().notifications;
+    expect(notifications.every((item) => item.isRead)).toBe(true);
+  });
+
+  it("clearAll이 알림과 pending을 함께 초기화해야 한다", () => {
+    const { addNotification, setPendingNotificationNavigation, clearAll } =
+      useNotificationStore.getState();
+
+    addNotification({ title: "A", body: "A", messageId: "clear-1" });
+    setPendingNotificationNavigation(true);
+
+    clearAll();
+
+    expect(useNotificationStore.getState().notifications).toEqual([]);
+    expect(useNotificationStore.getState().pendingNotificationNavigation).toBe(
+      false,
+    );
+  });
+});

--- a/src/features/notification/stores/useNotificationStore.ts
+++ b/src/features/notification/stores/useNotificationStore.ts
@@ -1,0 +1,78 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import type { NotificationItemProps } from "../types";
+
+interface NotificationState {
+  notifications: NotificationItemProps[];
+  pendingNotificationNavigation: boolean;
+  addNotification: (
+    notification: Omit<NotificationItemProps, "id" | "createdAt" | "isRead">,
+  ) => void;
+  markAsRead: (id: string) => void;
+  markAllAsRead: () => void;
+  clearAll: () => void;
+  setPendingNotificationNavigation: (value: boolean) => void;
+}
+
+export const useNotificationStore = create<NotificationState>()(
+  persist(
+    (set) => ({
+      notifications: [],
+      pendingNotificationNavigation: false,
+
+      setPendingNotificationNavigation: (value) =>
+        set({ pendingNotificationNavigation: value }),
+
+      // 새 알림 추가 (최신순 정렬)
+      addNotification: (content) =>
+        set((state) => {
+          if (
+            content.messageId &&
+            state.notifications.some(
+              (notification) => notification.messageId === content.messageId,
+            )
+          ) {
+            return state;
+          }
+
+          return {
+            notifications: [
+              {
+                ...content,
+                id: content.messageId ?? Date.now().toString(),
+                createdAt: new Date().toISOString(),
+                isRead: false,
+              },
+              ...state.notifications,
+            ].slice(0, 50), // 최대 50개 유지
+          };
+        }),
+
+      // 특정 알림 읽음 처리
+      markAsRead: (id) =>
+        set((state) => ({
+          notifications: state.notifications.map((n) =>
+            n.id === id ? { ...n, isRead: true } : n,
+          ),
+        })),
+
+      // 모두 읽음 처리
+      markAllAsRead: () =>
+        set((state) => ({
+          notifications: state.notifications.map((n) => ({
+            ...n,
+            isRead: true,
+          })),
+        })),
+
+      // 전체 삭제
+      clearAll: () =>
+        set({ notifications: [], pendingNotificationNavigation: false }),
+    }),
+    {
+      name: "notification-storage",
+      storage: createJSONStorage(() => AsyncStorage),
+    },
+  ),
+);

--- a/src/features/notification/stores/useNotificationStore.ts
+++ b/src/features/notification/stores/useNotificationStore.ts
@@ -27,25 +27,34 @@ export const useNotificationStore = create<NotificationState>()(
       // 새 알림 추가 (최신순 정렬)
       addNotification: (content) =>
         set((state) => {
-          if (
+          // messageId 기반 중복 체크
+          const isDuplicateId =
             content.messageId &&
+            state.notifications.some((n) => n.messageId === content.messageId);
+
+          //  아이디가 없는 경우를 대비해 제목과 내용으로 한 번 더 체크
+          const isDuplicateContent =
+            !content.messageId &&
             state.notifications.some(
-              (notification) => notification.messageId === content.messageId,
-            )
-          ) {
+              (n) => n.title === content.title && n.body === content.body,
+            );
+
+          if (isDuplicateId || isDuplicateContent) {
             return state;
           }
+
+          const tempId = `temp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
           return {
             notifications: [
               {
                 ...content,
-                id: content.messageId ?? Date.now().toString(),
+                id: content.messageId ?? tempId,
                 createdAt: new Date().toISOString(),
                 isRead: false,
               },
               ...state.notifications,
-            ].slice(0, 50), // 최대 50개 유지
+            ].slice(0, 50),
           };
         }),
 

--- a/src/features/notification/types/index.ts
+++ b/src/features/notification/types/index.ts
@@ -22,4 +22,19 @@ interface SettingRowProps {
   onCheckedChange?: (checked: boolean) => void;
 }
 
-export { DayButtonProps, PickerColumnProps, SettingRowProps };
+interface NotificationItemProps {
+  id: string;
+  title: string;
+  body: string;
+  createdAt: string;
+  isRead: boolean;
+  targetScreen?: string;
+  messageId?: string;
+}
+
+export type {
+  DayButtonProps,
+  NotificationItemProps,
+  PickerColumnProps,
+  SettingRowProps,
+};

--- a/src/shared/components/Header/Header.tsx
+++ b/src/shared/components/Header/Header.tsx
@@ -1,3 +1,4 @@
+import { useNotificationStore } from "@/features/notification/stores/useNotificationStore";
 import { Bell, ChevronLeft } from "@tamagui/lucide-icons";
 import { useRouter } from "expo-router";
 import React from "react";
@@ -11,6 +12,9 @@ export function Header({
 }: HeaderProps) {
   const insets = useSafeAreaInsets();
   const router = useRouter();
+  const hasUnreadNotifications = useNotificationStore((state) =>
+    state.notifications.some((notification) => !notification.isRead),
+  );
 
   return (
     <View backgroundColor="$background" style={{ paddingTop: insets.top }}>
@@ -54,7 +58,22 @@ export function Header({
               size="$4"
               circular
               chromeless
-              icon={<Bell size={24} color="$mainText" />}
+              icon={
+                <View position="relative">
+                  <Bell size={24} color="$mainText" />
+                  {hasUnreadNotifications && (
+                    <View
+                      position="absolute"
+                      top={-2}
+                      right={-2}
+                      width={8}
+                      height={8}
+                      borderRadius={100}
+                      backgroundColor="$warning"
+                    />
+                  )}
+                </View>
+              }
               pressStyle={{ opacity: 0.5 }}
               onPress={() => router.push("/notification")}
             />

--- a/src/shared/hooks/useNotificationHandler.test.ts
+++ b/src/shared/hooks/useNotificationHandler.test.ts
@@ -1,0 +1,204 @@
+import { useIsAuthLoaded } from "@/features/auth/store/useAuthStore";
+import { useNotificationStore } from "@/features/notification/stores/useNotificationStore";
+import {
+  getInitialNotification,
+  getMessaging,
+  onMessage,
+  onNotificationOpenedApp,
+} from "@react-native-firebase/messaging";
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+import { useNotificationHandler } from "./useNotificationHandler";
+
+jest.mock("@/features/auth/store/useAuthStore", () => ({
+  useIsAuthLoaded: jest.fn(),
+}));
+
+jest.mock("@/features/notification/stores/useNotificationStore", () => ({
+  useNotificationStore: jest.fn(),
+}));
+
+jest.mock("@react-native-firebase/messaging", () => ({
+  getMessaging: jest.fn(),
+  getInitialNotification: jest.fn(),
+  onMessage: jest.fn(),
+  onNotificationOpenedApp: jest.fn(),
+}));
+
+describe("useNotificationHandler 테스트", () => {
+  const mockedUseIsAuthLoaded = useIsAuthLoaded as jest.Mock;
+  const mockedUseNotificationStore =
+    useNotificationStore as unknown as jest.Mock;
+  const mockedGetMessaging = getMessaging as jest.Mock;
+  const mockedGetInitialNotification = getInitialNotification as jest.Mock;
+  const mockedOnMessage = onMessage as jest.Mock;
+  const mockedOnNotificationOpenedApp = onNotificationOpenedApp as jest.Mock;
+
+  const addNotificationMock = jest.fn();
+  const messagingInstance = { appName: "mock-fridge" };
+
+  const createRemoteMessage = (overrides: Record<string, unknown> = {}) =>
+    ({
+      messageId: "msg-1",
+      data: { target_screen: "FOOD_STATUS" },
+      notification: {
+        title: "유통기한 임박",
+        body: "우유가 내일 만료됩니다.",
+      },
+      ...overrides,
+    }) as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "log").mockImplementation(() => {});
+
+    mockedUseIsAuthLoaded.mockReturnValue(true);
+    mockedUseNotificationStore.mockImplementation((selector) =>
+      selector({ addNotification: addNotificationMock }),
+    );
+
+    mockedGetMessaging.mockReturnValue(messagingInstance);
+    mockedGetInitialNotification.mockResolvedValue(null);
+    mockedOnMessage.mockImplementation(() => jest.fn());
+    mockedOnNotificationOpenedApp.mockImplementation(() => jest.fn());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("로그인 또는 auth 로드가 되지 않으면 리스너를 등록하지 않아야 한다", () => {
+    mockedUseIsAuthLoaded.mockReturnValue(false);
+
+    renderHook(() => useNotificationHandler(true));
+    renderHook(() => useNotificationHandler(false));
+
+    expect(mockedOnMessage).not.toHaveBeenCalled();
+    expect(mockedOnNotificationOpenedApp).not.toHaveBeenCalled();
+  });
+
+  it("로그인 상태에서는 포그라운드/백그라운드 리스너를 등록하고 언마운트 시 해제해야 한다", () => {
+    const unsubscribeForeground = jest.fn();
+    const unsubscribeNotificationOpen = jest.fn();
+
+    mockedOnMessage.mockImplementation(() => unsubscribeForeground);
+    mockedOnNotificationOpenedApp.mockImplementation(
+      () => unsubscribeNotificationOpen,
+    );
+
+    const { unmount } = renderHook(() => useNotificationHandler(true));
+
+    expect(mockedOnMessage).toHaveBeenCalledWith(
+      messagingInstance,
+      expect.any(Function),
+    );
+    expect(mockedOnNotificationOpenedApp).toHaveBeenCalledWith(
+      messagingInstance,
+      expect.any(Function),
+    );
+
+    unmount();
+
+    expect(unsubscribeForeground).toHaveBeenCalledTimes(1);
+    expect(unsubscribeNotificationOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("수신한 메시지를 addNotification payload로 변환해 저장해야 한다", () => {
+    let foregroundCallback: ((remoteMessage: any) => void) | undefined;
+    let openCallback: ((remoteMessage: any) => void) | undefined;
+
+    mockedOnMessage.mockImplementation((_, callback) => {
+      foregroundCallback = callback;
+      return jest.fn();
+    });
+
+    mockedOnNotificationOpenedApp.mockImplementation((_, callback) => {
+      openCallback = callback;
+      return jest.fn();
+    });
+
+    renderHook(() => useNotificationHandler(true));
+
+    act(() => {
+      foregroundCallback?.(createRemoteMessage());
+    });
+
+    act(() => {
+      openCallback?.(
+        createRemoteMessage({
+          messageId: "msg-2",
+          data: { target_screen: "FOOD_STATUS" },
+        }),
+      );
+    });
+
+    expect(addNotificationMock).toHaveBeenNthCalledWith(1, {
+      title: "유통기한 임박",
+      body: "우유가 내일 만료됩니다.",
+      targetScreen: "FOOD_STATUS",
+      messageId: "msg-1",
+    });
+    expect(addNotificationMock).toHaveBeenNthCalledWith(2, {
+      title: "유통기한 임박",
+      body: "우유가 내일 만료됩니다.",
+      targetScreen: "FOOD_STATUS",
+      messageId: "msg-2",
+    });
+  });
+
+  it("notification 필드가 없으면 저장하지 않아야 한다", () => {
+    let foregroundCallback: ((remoteMessage: any) => void) | undefined;
+
+    mockedOnMessage.mockImplementation((_, callback) => {
+      foregroundCallback = callback;
+      return jest.fn();
+    });
+
+    renderHook(() => useNotificationHandler(true));
+
+    act(() => {
+      foregroundCallback?.({
+        messageId: "msg-empty",
+        data: { target_screen: "FOOD_STATUS" },
+      });
+    });
+
+    expect(addNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("종료 상태 초기 알림은 로그인 전에는 보류되고 로그인 후 한 번만 처리되어야 한다", async () => {
+    let resolveInitialNotification: (message: any) => void = () => {};
+    let isLoggedIn = false;
+
+    mockedGetInitialNotification.mockReturnValue(
+      new Promise((resolve) => {
+        resolveInitialNotification = resolve;
+      }),
+    );
+
+    const { rerender } = renderHook(() => useNotificationHandler(isLoggedIn));
+
+    await act(async () => {
+      resolveInitialNotification(
+        createRemoteMessage({
+          messageId: "msg-initial",
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    expect(addNotificationMock).not.toHaveBeenCalled();
+
+    isLoggedIn = true;
+    rerender(undefined);
+
+    await waitFor(() => {
+      expect(addNotificationMock).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(undefined);
+
+    await waitFor(() => {
+      expect(addNotificationMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/shared/hooks/useNotificationHandler.ts
+++ b/src/shared/hooks/useNotificationHandler.ts
@@ -1,0 +1,97 @@
+import { useIsAuthLoaded } from "@/features/auth/store/useAuthStore";
+import { useNotificationStore } from "@/features/notification/stores/useNotificationStore";
+import {
+  FirebaseMessagingTypes,
+  getInitialNotification,
+  getMessaging,
+  onMessage,
+  onNotificationOpenedApp,
+} from "@react-native-firebase/messaging";
+import { useCallback, useEffect, useRef } from "react";
+
+export const useNotificationHandler = (isLoggedIn: boolean) => {
+  const addNotification = useNotificationStore(
+    (state) => state.addNotification,
+  );
+  const isAuthLoaded = useIsAuthLoaded();
+  const pendingInitialNotificationRef =
+    useRef<FirebaseMessagingTypes.RemoteMessage | null>(null);
+  const consumedInitialNotificationRef = useRef(false);
+
+  const addRemoteMessageToStore = useCallback(
+    (remoteMessage: FirebaseMessagingTypes.RemoteMessage) => {
+      const targetScreen = remoteMessage.data?.target_screen;
+
+      if (remoteMessage.notification) {
+        addNotification({
+          title: remoteMessage.notification.title || "유통기한 임박",
+          body: remoteMessage.notification.body || "",
+          targetScreen:
+            typeof targetScreen === "string" ? targetScreen : undefined,
+          messageId: remoteMessage.messageId ?? undefined,
+        });
+      }
+    },
+    [addNotification],
+  );
+
+  const handleRemoteMessage = useCallback(
+    (remoteMessage: FirebaseMessagingTypes.RemoteMessage) => {
+      addRemoteMessageToStore(remoteMessage);
+    },
+    [addRemoteMessageToStore],
+  );
+
+  useEffect(() => {
+    const messaging = getMessaging();
+    let isMounted = true;
+
+    getInitialNotification(messaging).then((remoteMessage) => {
+      if (!isMounted || !remoteMessage) return;
+
+      console.log("종료 상태에서 알림으로 진입:", remoteMessage.data);
+      pendingInitialNotificationRef.current = remoteMessage;
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isLoggedIn || !isAuthLoaded) return;
+    if (consumedInitialNotificationRef.current) return;
+
+    const remoteMessage = pendingInitialNotificationRef.current;
+    if (!remoteMessage) return;
+
+    consumedInitialNotificationRef.current = true;
+    handleRemoteMessage(remoteMessage);
+    pendingInitialNotificationRef.current = null;
+  }, [isLoggedIn, isAuthLoaded, handleRemoteMessage]);
+
+  useEffect(() => {
+    // 로그인 상태가 아니면 리스너를 등록하지 않음
+    if (!isLoggedIn || !isAuthLoaded) return;
+
+    const messaging = getMessaging();
+
+    // 포어그라운드
+    const unsubscribeForeground = onMessage(messaging, (remoteMessage) => {
+      addRemoteMessageToStore(remoteMessage);
+    });
+
+    // 백그라운드에서 알림 클릭
+    const unsubscribeNotificationOpen = onNotificationOpenedApp(
+      messaging,
+      (remoteMessage) => {
+        handleRemoteMessage(remoteMessage);
+      },
+    );
+
+    return () => {
+      unsubscribeForeground();
+      unsubscribeNotificationOpen();
+    };
+  }, [isLoggedIn, isAuthLoaded, addRemoteMessageToStore, handleRemoteMessage]);
+};

--- a/src/shared/providers/SessionProvider.tsx
+++ b/src/shared/providers/SessionProvider.tsx
@@ -6,6 +6,7 @@ import {
 import { useRouter, useSegments } from "expo-router";
 import { useEffect } from "react";
 import { useFcmTokenSync } from "../hooks/useFcmTokenSync";
+import { useNotificationHandler } from "../hooks/useNotificationHandler";
 import { getSubFromToken } from "../lib/decodeJwt";
 import { useFcmSync } from "../lib/fcm/useFcmSync";
 
@@ -19,17 +20,18 @@ export function SessionProvider() {
   const { syncFcmToken } = useFcmTokenSync();
 
   useFcmSync(isLoggedIn ? stableUserId : null, syncFcmToken);
+  useNotificationHandler(isLoggedIn);
 
   useEffect(() => {
     if (!isLoaded) return;
-    const inAuthGroup = segments[0] === "(auth)";
+    const inAuthGroup = segments?.[0] === "(auth)";
 
     if (!isLoggedIn && !inAuthGroup) {
       router.replace("/(auth)/login");
-    } else if (isLoggedIn && (inAuthGroup || segments.length === 0)) {
+    } else if (isLoggedIn && inAuthGroup) {
       router.replace("/(tabs)");
     }
-  }, [isLoggedIn, isLoaded, segments]);
+  }, [isLoggedIn, isLoaded, segments, router]);
 
   return null;
 }

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -9,4 +9,23 @@ const getExpiryLabel = (dateString: string, daysLeft: number) => {
   return `${month}월 ${day}일`;
 };
 
-export { getExpiryLabel };
+const formatNotificationTime = (isoString: string) => {
+  const date = new Date(isoString);
+  const now = new Date();
+  const diffInMs = now.getTime() - date.getTime();
+  const diffInMins = Math.floor(diffInMs / (1000 * 60));
+  const diffInHours = Math.floor(diffInMins / 60);
+  const diffInDays = Math.floor(diffInHours / 24);
+
+  if (diffInMins < 1) return "방금 전";
+  if (diffInMins < 60) return `${diffInMins}분 전`;
+  if (diffInHours < 24) return `${diffInHours}시간 전`;
+  if (diffInDays < 7) return `${diffInDays}일 전`;
+
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+
+  return `${month}/${day}`;
+};
+
+export { formatNotificationTime, getExpiryLabel };


### PR DESCRIPTION
## 작업 내용

- 알림 관련 스토어 구현
- 헤더 벨 아이콘에 알림 미읽음 표시 구현
- 알림 수신 및 처리 로직 구현
- 알림 목록 페이지 구현

## 연관 이슈

- #48


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 푸시 알림 기능 추가 - 포그라운드 및 백그라운드 알림 수신 지원
  * 알림 센터 화면 추가 - 수신 알림 목록 조회, 개별/전체 읽음 처리 및 전체 삭제
  * 헤더에 알림 아이콘 배지 추가 - 읽지 않은 알림 시 시각적 표시
  * 알림 로컬 저장소 - 최근 50개 알림 자동 보관 및 중복 억제
  * 스플래시 애니메이션 재생 상태 유지로 재실행 시 재생 생략

* **테스트**
  * 알림 관련 로직 및 저장소 동작에 대한 포괄적 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->