### PR TITLE
Feat: 냉장고별 식재료 분류 및 전체 보기 탭 구현

### DIFF
--- a/src/features/food-add/hooks/mutations/useAddFoodMutation.ts
+++ b/src/features/food-add/hooks/mutations/useAddFoodMutation.ts
@@ -19,7 +19,7 @@ const useAddFoodMutation = (fridgeId: number) => {
       });
 
       queryClient.invalidateQueries({
-        queryKey: QUERY_KEYS.food.status(fridgeId),
+        queryKey: QUERY_KEYS.food.all,
       });
 
       if (router.canGoBack()) {

--- a/src/features/food-add/hooks/queries/useCategoryQuery.tsx
+++ b/src/features/food-add/hooks/queries/useCategoryQuery.tsx
@@ -1,10 +1,16 @@
 import { useApiQuery } from "@/shared/apis/builder/ApiBuilder";
 import { getCategoryApi } from "../../apis/category";
 
-const useCategoryQuery = (fridgeId: number) => {
-  return useApiQuery(getCategoryApi(fridgeId), ["categories", fridgeId], {
-    enabled: !!fridgeId,
-  });
+const useCategoryQuery = (fridgeId: number | null) => {
+  const targetFridgeId = fridgeId ?? 0;
+
+  return useApiQuery(
+    getCategoryApi(targetFridgeId),
+    ["categories", targetFridgeId],
+    {
+      enabled: fridgeId !== null && fridgeId !== 0,
+    },
+  );
 };
 
 export { useCategoryQuery };

--- a/src/features/food-add/screens/FoodAddScreen.tsx
+++ b/src/features/food-add/screens/FoodAddScreen.tsx
@@ -1,8 +1,13 @@
+import { useFridgeQuery } from "@/features/home/hooks/queries/useFridgeQuery";
 import { Header } from "@/shared/components/Header/Header";
-import { useSelectedFridgeId } from "@/shared/stores/useFridgeStore";
-import React, { useEffect, useState } from "react";
+import {
+  useFridgeActions,
+  useSelectedFridgeId,
+} from "@/shared/stores/useFridgeStore";
+import React, { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
-import { Button, ScrollView, Text, YStack } from "tamagui";
+import Toast from "react-native-toast-message";
+import { Button, ScrollView, Text, XStack, YStack } from "tamagui";
 import { CategorySelector } from "../components/CategorySelector/CategorySelector";
 import { ExpiryDatePicker } from "../components/ExpiryDatePicker/ExpiryDatePicker";
 import { FoodNameInput } from "../components/FoodNameInput";
@@ -15,10 +20,22 @@ import { FoodFormValues } from "../types";
 
 export function FoodAddScreen() {
   const selectedFridgeId = useSelectedFridgeId();
-  const { data: categoryData } = useCategoryQuery(selectedFridgeId!);
-  const categories = categoryData?.data || [];
+  const { setSelectedFridgeId } = useFridgeActions();
+  const { data: fridgeData } = useFridgeQuery();
+  const fridges = useMemo(() => fridgeData?.data ?? [], [fridgeData?.data]);
 
-  const { mutate: addFood, isPending } = useAddFoodMutation(selectedFridgeId!);
+  const [targetFridgeId, setTargetFridgeId] = useState<number | null>(
+    selectedFridgeId,
+  );
+  const { data: categoryData } = useCategoryQuery(targetFridgeId);
+  const categories = useMemo(
+    () => categoryData?.data ?? [],
+    [categoryData?.data],
+  );
+
+  const { mutate: addFood, isPending } = useAddFoodMutation(
+    targetFridgeId ?? 0,
+  );
   const { control, handleSubmit, setValue } = useForm<FoodFormValues>({
     mode: "onChange",
     defaultValues: {
@@ -32,6 +49,14 @@ export function FoodAddScreen() {
   });
   const [isCategoryModalOpen, setIsCategoryModalOpen] = useState(false);
 
+  useEffect(() => {
+    if (targetFridgeId === null && fridges.length > 0) {
+      const firstFridgeId = fridges[0].id;
+      setTargetFridgeId(firstFridgeId);
+      setSelectedFridgeId(firstFridgeId);
+    }
+  }, [fridges, setSelectedFridgeId, targetFridgeId]);
+
   // 데이터 로드 시 첫 번째 값 설정
   useEffect(() => {
     if (categories.length > 0) {
@@ -40,6 +65,14 @@ export function FoodAddScreen() {
   }, [categories, setValue]);
 
   const onSubmit = (data: FoodFormValues) => {
+    if (targetFridgeId === null) {
+      Toast.show({
+        type: "error",
+        text1: "등록할 냉장고를 선택해주세요.",
+      });
+      return;
+    }
+
     addFood(data);
   };
 
@@ -48,14 +81,46 @@ export function FoodAddScreen() {
       <Header title="식품 추가" showBackButton />
       <ScrollView f={1} showsVerticalScrollIndicator={false}>
         <YStack p="$4" gap="$5" pb="$10">
+          <YStack gap="$2">
+            <Text fontFamily="$baemin" fontSize="$4" color="$mainText">
+              등록 냉장고
+            </Text>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+              <XStack gap="$2">
+                {fridges.map((fridge) => {
+                  const isActive = targetFridgeId === fridge.id;
+                  return (
+                    <Button
+                      key={fridge.id}
+                      onPress={() => {
+                        setTargetFridgeId(fridge.id);
+                        setSelectedFridgeId(fridge.id);
+                      }}
+                      bg={isActive ? "$primary" : "$gray3"}
+                      borderWidth={1}
+                      borderColor={isActive ? "$primary" : "$gray3"}
+                      size="$4"
+                      br="$4"
+                      px="$4"
+                    >
+                      <Text fontFamily="$baemin" color="$mainText">
+                        {fridge.name}
+                      </Text>
+                    </Button>
+                  );
+                })}
+              </XStack>
+            </ScrollView>
+          </YStack>
+
           <ImageUploader control={control} />
           <FoodNameInput control={control} />
-          {selectedFridgeId !== null && (
+          {targetFridgeId !== null && (
             <CategorySelector
               control={control}
               categories={categories}
               onModalOpenChange={setIsCategoryModalOpen}
-              fridgeId={selectedFridgeId!}
+              fridgeId={targetFridgeId}
             />
           )}
           <StorageSelector control={control} />
@@ -71,7 +136,7 @@ export function FoodAddScreen() {
             size="$6"
             br="$3"
             onPress={handleSubmit(onSubmit)}
-            disabled={isPending}
+            disabled={isPending || targetFridgeId === null}
           >
             <Text
               color="$mainText"

--- a/src/features/food-add/screens/FoodAddScreen.tsx
+++ b/src/features/food-add/screens/FoodAddScreen.tsx
@@ -2,9 +2,11 @@ import { useFridgeQuery } from "@/features/home/hooks/queries/useFridgeQuery";
 import { Header } from "@/shared/components/Header/Header";
 import {
   useFridgeActions,
+  useIsAllFridgeTab,
   useSelectedFridgeId,
 } from "@/shared/stores/useFridgeStore";
-import React, { useEffect, useMemo, useState } from "react";
+import { useIsFocused } from "@react-navigation/native";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import Toast from "react-native-toast-message";
 import { Button, ScrollView, Text, XStack, YStack } from "tamagui";
@@ -20,14 +22,18 @@ import { FoodFormValues } from "../types";
 
 export function FoodAddScreen() {
   const selectedFridgeId = useSelectedFridgeId();
+  const isAllFridgeTab = useIsAllFridgeTab();
   const { setSelectedFridgeId } = useFridgeActions();
+  const isFocused = useIsFocused();
   const { data: fridgeData } = useFridgeQuery();
   const fridges = useMemo(() => fridgeData?.data ?? [], [fridgeData?.data]);
 
-  const [targetFridgeId, setTargetFridgeId] = useState<number | null>(
-    selectedFridgeId,
-  );
-  const { data: categoryData } = useCategoryQuery(targetFridgeId);
+  const [targetFridgeId, setTargetFridgeId] = useState<number | null>(null);
+  const {
+    data: categoryData,
+    isLoading: isCategoryLoading,
+    isFetching: isCategoryFetching,
+  } = useCategoryQuery(targetFridgeId);
   const categories = useMemo(
     () => categoryData?.data ?? [],
     [categoryData?.data],
@@ -36,7 +42,7 @@ export function FoodAddScreen() {
   const { mutate: addFood, isPending } = useAddFoodMutation(
     targetFridgeId ?? 0,
   );
-  const { control, handleSubmit, setValue } = useForm<FoodFormValues>({
+  const { control, handleSubmit, setValue, watch } = useForm<FoodFormValues>({
     mode: "onChange",
     defaultValues: {
       name: "",
@@ -48,27 +54,59 @@ export function FoodAddScreen() {
     },
   });
   const [isCategoryModalOpen, setIsCategoryModalOpen] = useState(false);
+  const selectedCategoryId = watch("categoryId");
+  const isCategoryValid = categories.some(
+    (category) => category.id === selectedCategoryId,
+  );
+  const isTargetReady = targetFridgeId !== null;
+  const isCategoryReady =
+    isTargetReady &&
+    !isCategoryLoading &&
+    !isCategoryFetching &&
+    categories.length > 0 &&
+    isCategoryValid;
+  const wasFocusedRef = useRef(false);
 
   useEffect(() => {
-    if (targetFridgeId === null && fridges.length > 0) {
-      const firstFridgeId = fridges[0].id;
-      setTargetFridgeId(firstFridgeId);
-      setSelectedFridgeId(firstFridgeId);
+    if (isFocused && !wasFocusedRef.current) {
+      if (isAllFridgeTab) {
+        setTargetFridgeId(null);
+      } else {
+        setTargetFridgeId(selectedFridgeId);
+      }
+
+      setValue("categoryId", 0);
     }
-  }, [fridges, setSelectedFridgeId, targetFridgeId]);
+
+    wasFocusedRef.current = isFocused;
+  }, [isAllFridgeTab, isFocused, selectedFridgeId, setValue]);
+
+  useEffect(() => {
+    if (targetFridgeId !== null) {
+      setValue("categoryId", 0);
+    }
+  }, [targetFridgeId, setValue]);
 
   // 데이터 로드 시 첫 번째 값 설정
   useEffect(() => {
-    if (categories.length > 0) {
+    if (categories.length > 0 && !isCategoryValid) {
       setValue("categoryId", categories[0].id);
     }
-  }, [categories, setValue]);
+  }, [categories, isCategoryValid, setValue]);
 
   const onSubmit = (data: FoodFormValues) => {
-    if (targetFridgeId === null) {
+    if (!isTargetReady) {
       Toast.show({
         type: "error",
         text1: "등록할 냉장고를 선택해주세요.",
+      });
+      return;
+    }
+
+    if (!isCategoryReady) {
+      Toast.show({
+        type: "error",
+        text1: "카테고리 준비 후 다시 시도해주세요.",
       });
       return;
     }
@@ -136,7 +174,7 @@ export function FoodAddScreen() {
             size="$6"
             br="$3"
             onPress={handleSubmit(onSubmit)}
-            disabled={isPending || targetFridgeId === null}
+            disabled={isPending || !isTargetReady || !isCategoryReady}
           >
             <Text
               color="$mainText"

--- a/src/features/home/__tests__/apis/food.test.ts
+++ b/src/features/home/__tests__/apis/food.test.ts
@@ -1,9 +1,23 @@
-import { getFoodStatusApi } from "../../apis/food";
+import { getFoodStatusApi, getFridgeFoodsApi } from "../../apis/food";
 
 describe("Food API 테스트", () => {
   it("getFoodStatusApi는 올바른 URL과 메소드로 설정되어야 한다", () => {
     const api = getFoodStatusApi as any;
     expect(api.endpoint).toBe("/api/v1/foods/status");
     expect(api.method).toBe("GET");
+  });
+
+  it("getFridgeFoodsApi는 냉장고별 조회 URL, 메소드, params가 올바르게 설정되어야 한다", () => {
+    const api = getFridgeFoodsApi(3, {
+      size: 50,
+      sortBy: "EXPIRATION",
+    }) as any;
+
+    expect(api.endpoint).toBe("/api/v1/refrigerators/3/foods");
+    expect(api.method).toBe("GET");
+    expect(api.config.params).toEqual({
+      size: 50,
+      sortBy: "EXPIRATION",
+    });
   });
 });

--- a/src/features/home/__tests__/hooks/useFridgeFoodStatusQuery.test.tsx
+++ b/src/features/home/__tests__/hooks/useFridgeFoodStatusQuery.test.tsx
@@ -1,0 +1,136 @@
+import apiClient from "@/shared/apis/apiClient";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react-native";
+import React from "react";
+import { useFridgeFoodStatusQuery } from "../../hooks/queries/useFridgeFoodStatusQuery";
+
+jest.mock("@/shared/apis/apiClient");
+const mockedApiClient = apiClient as jest.MockedFunction<typeof apiClient>;
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false, gcTime: 0 },
+  },
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe("useFridgeFoodStatusQuery 테스트", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient.clear();
+  });
+
+  afterAll(() => {
+    queryClient.clear();
+  });
+
+  it("냉장고별 조회 응답을 상태별 데이터로 변환해야 한다", async () => {
+    mockedApiClient.mockResolvedValueOnce({
+      data: {
+        result: "SUCCESS",
+        data: {
+          foods: [
+            {
+              id: 1,
+              name: "우유",
+              categoryName: "유제품",
+              imageURL: "",
+              quantity: { amount: 1, unit: "L" },
+              condition: {
+                expirationDate: "2026-03-20",
+                storageType: "REFRIGERATION",
+                foodStatus: "RED",
+                daysLeft: 1,
+              },
+            },
+            {
+              id: 2,
+              name: "김치",
+              categoryName: "반찬",
+              imageURL: "",
+              quantity: { amount: 1, unit: "KG" },
+              condition: {
+                expirationDate: "2026-04-20",
+                storageType: "REFRIGERATION",
+                foodStatus: "GREEN",
+                daysLeft: 30,
+              },
+            },
+          ],
+        },
+      },
+    } as any);
+
+    const { result } = renderHook(() => useFridgeFoodStatusQuery(7), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockedApiClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "/api/v1/refrigerators/7/foods",
+        method: "GET",
+        params: {
+          size: 50,
+          sortBy: "EXPIRATION",
+        },
+      }),
+    );
+
+    expect(result.current.data?.data.redCount).toBe(1);
+    expect(result.current.data?.data.greenCount).toBe(1);
+    expect(result.current.data?.data.blackCount).toBe(0);
+    expect(result.current.data?.data.yellowCount).toBe(0);
+  });
+
+  it("fridgeId가 없으면 쿼리를 실행하지 않아야 한다", () => {
+    const { result } = renderHook(() => useFridgeFoodStatusQuery(null), {
+      wrapper,
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockedApiClient).not.toHaveBeenCalled();
+  });
+
+  it("content 키 배열 응답도 정상 변환해야 한다", async () => {
+    mockedApiClient.mockResolvedValueOnce({
+      data: {
+        result: "SUCCESS",
+        data: {
+          content: [
+            {
+              id: 9,
+              name: "아이스크림",
+              categoryName: "간식",
+              imageURL: "",
+              quantity: { amount: 2, unit: "PIECE" },
+              condition: {
+                expirationDate: "2026-03-21",
+                storageType: "FROZEN",
+                foodStatus: "YELLOW",
+                daysLeft: 2,
+              },
+            },
+          ],
+        },
+      },
+    } as any);
+
+    const { result } = renderHook(() => useFridgeFoodStatusQuery(11), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.data.yellowCount).toBe(1);
+    expect(result.current.data?.data.yellow[0].id).toBe(9);
+  });
+});

--- a/src/features/home/apis/food.ts
+++ b/src/features/home/apis/food.ts
@@ -9,14 +9,14 @@ const getFoodStatusApi = ApiBuilder.create<void, FoodStatusResponse>(
   "/api/v1/foods/status",
 ).setMethod("GET");
 
-const getRefrigeratorFoodsApi = (
-  refrigeratorId: number,
+const getFridgeFoodsApi = (
+  fridgeId: number,
   cursorRequest: FridgeFoodsCursorRequest,
 ) =>
   ApiBuilder.create<void, FridgeFoodsResponseRaw>(
-    `/api/v1/refrigerators/${refrigeratorId}/foods`,
+    `/api/v1/refrigerators/${fridgeId}/foods`,
   )
     .setMethod("GET")
     .setParams(cursorRequest);
 
-export { getFoodStatusApi, getRefrigeratorFoodsApi };
+export { getFoodStatusApi, getFridgeFoodsApi };

--- a/src/features/home/apis/food.ts
+++ b/src/features/home/apis/food.ts
@@ -1,8 +1,22 @@
 import ApiBuilder from "@/shared/apis/builder/ApiBuilder";
-import type { FoodStatusResponse } from "./food.types";
+import type {
+  FoodStatusResponse,
+  FridgeFoodsCursorRequest,
+  FridgeFoodsResponseRaw,
+} from "./food.types";
 
 const getFoodStatusApi = ApiBuilder.create<void, FoodStatusResponse>(
   "/api/v1/foods/status",
 ).setMethod("GET");
 
-export { getFoodStatusApi };
+const getRefrigeratorFoodsApi = (
+  refrigeratorId: number,
+  cursorRequest: FridgeFoodsCursorRequest,
+) =>
+  ApiBuilder.create<void, FridgeFoodsResponseRaw>(
+    `/api/v1/refrigerators/${refrigeratorId}/foods`,
+  )
+    .setMethod("GET")
+    .setParams(cursorRequest);
+
+export { getFoodStatusApi, getRefrigeratorFoodsApi };

--- a/src/features/home/apis/food.types.ts
+++ b/src/features/home/apis/food.types.ts
@@ -1,4 +1,4 @@
-import { FoodItem } from "@/shared/types/food";
+import { FoodItem, StorageType } from "@/shared/types/food";
 
 type FoodStatusData = {
   black: FoodItem[];
@@ -16,4 +16,33 @@ interface FoodStatusResponse {
   data: FoodStatusData;
 }
 
-export { FoodStatusResponse };
+type FoodCursorSortBy = "EXPIRATION" | "CREATED" | "NAME";
+
+interface FridgeFoodsCursorRequest {
+  cursorId?: number;
+  size?: number;
+  sortBy?: FoodCursorSortBy;
+  storageType?: StorageType;
+}
+
+// 커서 기반 응답
+interface FridgeFoodsDataRaw {
+  foods?: FoodItem[];
+  content?: FoodItem[];
+  items?: FoodItem[];
+}
+
+interface FridgeFoodsResponseRaw {
+  result: string;
+  data: FridgeFoodsDataRaw | FoodItem[];
+  nextCursorId?: number | null;
+  hasMore?: boolean;
+}
+
+export type {
+  FoodCursorSortBy,
+  FoodStatusData,
+  FoodStatusResponse,
+  FridgeFoodsCursorRequest,
+  FridgeFoodsResponseRaw,
+};

--- a/src/features/home/components/FridgeTabScroll.tsx
+++ b/src/features/home/components/FridgeTabScroll.tsx
@@ -4,6 +4,8 @@ import { FridgeTabScrollProps } from "../types";
 
 export function FridgeTabScroll({
   selectedId,
+  isAllSelected,
+  onSelectAll,
   onSelect,
   data = [],
 }: FridgeTabScrollProps) {
@@ -14,8 +16,28 @@ export function FridgeTabScroll({
       contentContainerStyle={{ paddingHorizontal: 16 }}
     >
       <XStack gap="$2" ai="center" backgroundColor="$background">
+        <Button
+          onPress={onSelectAll}
+          bg={isAllSelected ? "$secondary" : "$white"}
+          size="$4"
+          br="$4"
+          px="$5"
+          fontSize="$2"
+          hoverStyle={{ scale: 0.95 }}
+          pressStyle={{ scale: 0.9 }}
+        >
+          <Text
+            fontFamily="$baemin"
+            fontSize="$3"
+            color={isAllSelected ? "white" : "$gray"}
+            fontWeight={isAllSelected ? "700" : "400"}
+          >
+            전체
+          </Text>
+        </Button>
+
         {data.map((fridge) => {
-          const isActive = selectedId === fridge.id;
+          const isActive = !isAllSelected && selectedId === fridge.id;
           return (
             <Button
               key={fridge.id}

--- a/src/features/home/hooks/queries/useAllFoodStatusQuery.ts
+++ b/src/features/home/hooks/queries/useAllFoodStatusQuery.ts
@@ -1,0 +1,11 @@
+import { useApiQuery } from "@/shared/apis/builder/ApiBuilder";
+import { QUERY_KEYS } from "@/shared/constants/queryKeys";
+import { getFoodStatusApi } from "../../apis/food";
+
+const useAllFoodStatusQuery = (enabled = true) => {
+  return useApiQuery(getFoodStatusApi, QUERY_KEYS.food.statusAll(), {
+    enabled,
+  });
+};
+
+export { useAllFoodStatusQuery };

--- a/src/features/home/hooks/queries/useFridgeFoodStatusQuery.ts
+++ b/src/features/home/hooks/queries/useFridgeFoodStatusQuery.ts
@@ -1,0 +1,153 @@
+import { QUERY_KEYS } from "@/shared/constants/queryKeys";
+import { FoodItem } from "@/shared/types/food";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { getRefrigeratorFoodsApi } from "../../apis/food";
+import type {
+  FoodStatusData,
+  FoodStatusResponse,
+  FridgeFoodsCursorRequest,
+  FridgeFoodsResponseRaw,
+} from "../../apis/food.types";
+
+const DEFAULT_CURSOR_REQUEST: FridgeFoodsCursorRequest = {
+  size: 50,
+  sortBy: "EXPIRATION",
+};
+
+interface UseRefrigeratorFoodStatusQueryReturn {
+  // 상태별로 분류된 데이터
+  data?: FoodStatusResponse;
+  // 다음 페이지가 있는지
+  hasMore: boolean;
+  fetchNextPage: () => void;
+  // 현재 페이지 페칭중
+  isFetching: boolean;
+  isLoading: boolean;
+  isSuccess: boolean;
+  fetchStatus: "idle" | "fetching" | "paused";
+}
+
+const createEmptyFoodStatusData = (): FoodStatusData => ({
+  black: [],
+  red: [],
+  yellow: [],
+  green: [],
+  blackCount: 0,
+  redCount: 0,
+  yellowCount: 0,
+  greenCount: 0,
+});
+
+const extractFoods = (data: FridgeFoodsResponseRaw["data"]): FoodItem[] => {
+  if (Array.isArray(data)) {
+    return data;
+  }
+
+  if (Array.isArray(data.foods)) {
+    return data.foods;
+  }
+
+  if (Array.isArray(data.content)) {
+    return data.content;
+  }
+
+  if (Array.isArray(data.items)) {
+    return data.items;
+  }
+
+  return [];
+};
+
+// 식품 배열을 상태별로 분류
+const groupFoodsByStatus = (foods: FoodItem[]): FoodStatusData => {
+  const grouped = createEmptyFoodStatusData();
+
+  foods.forEach((food) => {
+    const foodStatus = food.condition?.foodStatus;
+
+    if (foodStatus === "BLACK") {
+      grouped.black.push(food);
+      grouped.blackCount += 1;
+      return;
+    }
+
+    if (foodStatus === "RED") {
+      grouped.red.push(food);
+      grouped.redCount += 1;
+      return;
+    }
+
+    if (foodStatus === "YELLOW") {
+      grouped.yellow.push(food);
+      grouped.yellowCount += 1;
+      return;
+    }
+
+    if (foodStatus === "GREEN") {
+      grouped.green.push(food);
+      grouped.greenCount += 1;
+    }
+  });
+
+  return grouped;
+};
+
+// 무한 스크롤 쿼리 훅
+const useFridgeFoodStatusQuery = (
+  fridgeId: number | null,
+  enabled = true,
+): UseRefrigeratorFoodStatusQueryReturn => {
+  const query = useInfiniteQuery<FridgeFoodsResponseRaw>({
+    queryKey: QUERY_KEYS.food.statusByRefrigerator(fridgeId ?? 0),
+    queryFn: async ({ pageParam }) => {
+      // cursorId를 포함하여 api 호출
+      const response = await getRefrigeratorFoodsApi(fridgeId ?? 0, {
+        ...DEFAULT_CURSOR_REQUEST,
+        cursorId: pageParam as number | undefined,
+      }).execute();
+      return response.data;
+    },
+
+    // 다음 페이지의 cursorId를 추출
+    getNextPageParam: (lastPage) => {
+      return (lastPage.nextCursorId ?? undefined) as number | undefined;
+    },
+    // 첫 페이지는 cursorId 없이 시작
+    initialPageParam: undefined,
+    enabled: enabled && fridgeId !== null,
+  });
+
+  // 모든 페이지의 식품을 누적하고 상태별로 그룹화
+  const mappedData = useMemo<FoodStatusResponse | undefined>(() => {
+    if (!query.data?.pages || query.data.pages.length === 0) {
+      return undefined;
+    }
+
+    const allFoods: FoodItem[] = [];
+    query.data.pages.forEach((page: any) => {
+      const foods = extractFoods(page.data);
+      allFoods.push(...foods);
+    });
+
+    // 누적된 식품을 상태별로 분류하여 반환
+    return {
+      result: "SUCCESS",
+      data: groupFoodsByStatus(allFoods),
+    };
+  }, [query.data?.pages]);
+
+  const hasMore = query.hasNextPage ?? false;
+
+  return {
+    data: mappedData,
+    hasMore,
+    fetchNextPage: query.fetchNextPage as () => void,
+    isFetching: query.isFetching,
+    isLoading: query.isLoading,
+    isSuccess: query.isSuccess,
+    fetchStatus: query.fetchStatus,
+  };
+};
+
+export { useFridgeFoodStatusQuery };

--- a/src/features/home/hooks/queries/useFridgeFoodStatusQuery.ts
+++ b/src/features/home/hooks/queries/useFridgeFoodStatusQuery.ts
@@ -2,7 +2,7 @@ import { QUERY_KEYS } from "@/shared/constants/queryKeys";
 import { FoodItem } from "@/shared/types/food";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
-import { getRefrigeratorFoodsApi } from "../../apis/food";
+import { getFridgeFoodsApi } from "../../apis/food";
 import type {
   FoodStatusData,
   FoodStatusResponse,
@@ -102,7 +102,7 @@ const useFridgeFoodStatusQuery = (
     queryKey: QUERY_KEYS.food.statusByRefrigerator(fridgeId ?? 0),
     queryFn: async ({ pageParam }) => {
       // cursorId를 포함하여 api 호출
-      const response = await getRefrigeratorFoodsApi(fridgeId ?? 0, {
+      const response = await getFridgeFoodsApi(fridgeId ?? 0, {
         ...DEFAULT_CURSOR_REQUEST,
         cursorId: pageParam as number | undefined,
       }).execute();

--- a/src/features/home/screens/HomeScreen.tsx
+++ b/src/features/home/screens/HomeScreen.tsx
@@ -13,7 +13,8 @@ import { FoodListItem } from "../components/FoodListItem";
 import { FridgeTabScroll } from "../components/FridgeTabScroll";
 import { HomeSkeleton } from "../components/HomeSkeleton";
 import { SortFilter } from "../components/SortFilter";
-import { useFoodStatusQuery } from "../hooks/queries/useFoodStatusQuery";
+import { useAllFoodStatusQuery } from "../hooks/queries/useAllFoodStatusQuery";
+import { useFridgeFoodStatusQuery } from "../hooks/queries/useFridgeFoodStatusQuery";
 import { useFridgeQuery } from "../hooks/queries/useFridgeQuery";
 import { FoodStatus, SortOption } from "../types";
 
@@ -22,6 +23,7 @@ export function HomeScreen() {
   // 첫번째 냉장고를 기본값으로 설정
   const selectedFridgeId = useSelectedFridgeId();
   const { setSelectedFridgeId } = useFridgeActions();
+  const [isAllFridgeTab, setIsAllFridgeTab] = useState(true);
 
   // 냉장고 목록 로드 완료 시 첫 번째 ID 설정
   useEffect(() => {
@@ -33,9 +35,23 @@ export function HomeScreen() {
     }
   }, [fridgeData, selectedFridgeId, setSelectedFridgeId]);
 
-  const { data: foodStatusData, isLoading: isFoodLoading } = useFoodStatusQuery(
-    selectedFridgeId || 0,
-  );
+  const { data: allFoodStatusData, isLoading: isAllFoodLoading } =
+    useAllFoodStatusQuery(isAllFridgeTab);
+
+  const {
+    data: fridgeFoodStatusData,
+    isLoading: isRefrigeratorFoodLoading,
+    fetchNextPage: fetchNextFridgePage,
+    hasMore: hasMoreFridgeFood,
+  } = useFridgeFoodStatusQuery(selectedFridgeId, !isAllFridgeTab);
+
+  const foodStatusData = isAllFridgeTab
+    ? allFoodStatusData
+    : fridgeFoodStatusData;
+
+  const isFoodLoading = isAllFridgeTab
+    ? isAllFoodLoading
+    : isRefrigeratorFoodLoading;
 
   const [currentTab, setCurrentTab] = useState("전체");
   const [statusFilter, setStatusFilter] = useState<FoodStatus | null>(null);
@@ -102,8 +118,10 @@ export function HomeScreen() {
     });
   }, [allFoods, currentTab, statusFilter, selectedCategory, sortOption]);
 
-  const currentFridgeName =
-    fridgeData?.data?.find((f) => f.id === selectedFridgeId)?.name || "냉장고";
+  const currentFridgeName = isAllFridgeTab
+    ? "전체"
+    : fridgeData?.data?.find((f) => f.id === selectedFridgeId)?.name ||
+      "냉장고";
 
   if (isFridgeLoading || isFoodLoading) {
     return (
@@ -120,7 +138,12 @@ export function HomeScreen() {
       <YStack gap="$5">
         <FridgeTabScroll
           selectedId={selectedFridgeId}
-          onSelect={(fridge) => setSelectedFridgeId(fridge.id)}
+          isAllSelected={isAllFridgeTab}
+          onSelectAll={() => setIsAllFridgeTab(true)}
+          onSelect={(fridge) => {
+            setSelectedFridgeId(fridge.id);
+            setIsAllFridgeTab(false);
+          }}
           data={fridgeData?.data}
         />
         <Expiry
@@ -159,6 +182,12 @@ export function HomeScreen() {
           keyExtractor={(item) => item.id.toString()}
           //@ts-ignore
           contentContainerStyle={{ paddingBottom: 40 }}
+          onEndReached={() => {
+            if (!isAllFridgeTab && hasMoreFridgeFood) {
+              fetchNextFridgePage();
+            }
+          }}
+          onEndReachedThreshold={0.5}
           ListEmptyComponent={
             <YStack ai="center" jc="center" py="$10">
               <Text color="$gray">해당 카테고리에 음식이 없습니다.</Text>

--- a/src/features/home/screens/HomeScreen.tsx
+++ b/src/features/home/screens/HomeScreen.tsx
@@ -1,6 +1,7 @@
 import { Header } from "@/shared/components/Header/Header";
 import {
   useFridgeActions,
+  useIsAllFridgeTab,
   useSelectedFridgeId,
 } from "@/shared/stores/useFridgeStore";
 import { FlashList } from "@shopify/flash-list";
@@ -20,10 +21,9 @@ import { FoodStatus, SortOption } from "../types";
 
 export function HomeScreen() {
   const { data: fridgeData, isLoading: isFridgeLoading } = useFridgeQuery();
-  // 첫번째 냉장고를 기본값으로 설정
   const selectedFridgeId = useSelectedFridgeId();
-  const { setSelectedFridgeId } = useFridgeActions();
-  const [isAllFridgeTab, setIsAllFridgeTab] = useState(true);
+  const isAllFridgeTab = useIsAllFridgeTab();
+  const { setSelectedFridgeId, setIsAllFridgeTab } = useFridgeActions();
 
   // 냉장고 목록 로드 완료 시 첫 번째 ID 설정
   useEffect(() => {

--- a/src/features/home/types/index.ts
+++ b/src/features/home/types/index.ts
@@ -25,6 +25,8 @@ interface StatusItemProps {
 
 interface FridgeTabScrollProps {
   selectedId: number | null;
+  isAllSelected: boolean;
+  onSelectAll: () => void;
   onSelect: (fridge: Fridge) => void;
 
   data?: Fridge[];

--- a/src/shared/constants/queryKeys.ts
+++ b/src/shared/constants/queryKeys.ts
@@ -11,8 +11,11 @@ const QUERY_KEYS = {
   },
   food: {
     all: ["foods"] as const,
+    statusAll: () => [...QUERY_KEYS.food.all, "status", "all"] as const,
     status: (fridgeId: number) =>
       [...QUERY_KEYS.food.all, "status", fridgeId] as const,
+    statusByRefrigerator: (fridgeId: number) =>
+      [...QUERY_KEYS.food.all, "statusByRefrigerator", fridgeId] as const,
   },
   notification: {
     all: ["notifications"] as const,

--- a/src/shared/stores/useFridgeStore.test.ts
+++ b/src/shared/stores/useFridgeStore.test.ts
@@ -4,12 +4,18 @@ describe("FridgeStore 테스트", () => {
   beforeEach(() => {
     useFridgeStore.setState({
       selectedFridgeId: null,
+      isAllFridgeTab: true,
     });
   });
 
   it("초기 상태의 selectedFridgeId는 null이어야 한다.", () => {
     const state = useFridgeStore.getState();
     expect(state.selectedFridgeId).toBeNull();
+  });
+
+  it("초기 상태의 isAllFridgeTab은 true여야 한다.", () => {
+    const state = useFridgeStore.getState();
+    expect(state.isAllFridgeTab).toBe(true);
   });
 
   it("setSelectedFridgeId 액션이 selectedFridgeId 상태를 변경해야 한다.", () => {
@@ -28,5 +34,13 @@ describe("FridgeStore 테스트", () => {
     setSelectedFridgeId(99);
 
     expect(useFridgeStore.getState().selectedFridgeId).toBe(99);
+  });
+
+  it("setIsAllFridgeTab 액션이 탭 상태를 변경해야 한다.", () => {
+    const { setIsAllFridgeTab } = useFridgeStore.getState().actions;
+
+    setIsAllFridgeTab(false);
+
+    expect(useFridgeStore.getState().isAllFridgeTab).toBe(false);
   });
 });

--- a/src/shared/stores/useFridgeStore.ts
+++ b/src/shared/stores/useFridgeStore.ts
@@ -3,10 +3,12 @@ import { combine, devtools } from "zustand/middleware";
 
 type State = {
   selectedFridgeId: number | null;
+  isAllFridgeTab: boolean;
 };
 
 const initialState: State = {
   selectedFridgeId: null,
+  isAllFridgeTab: true,
 };
 
 const useFridgeStore = create(
@@ -16,6 +18,9 @@ const useFridgeStore = create(
         setSelectedFridgeId: (id: number) => {
           set({ selectedFridgeId: id });
         },
+        setIsAllFridgeTab: (isAll: boolean) => {
+          set({ isAllFridgeTab: isAll });
+        },
       },
     })),
     { name: "fridgeStore" },
@@ -24,6 +29,12 @@ const useFridgeStore = create(
 
 const useSelectedFridgeId = () =>
   useFridgeStore((state) => state.selectedFridgeId);
+const useIsAllFridgeTab = () => useFridgeStore((state) => state.isAllFridgeTab);
 const useFridgeActions = () => useFridgeStore((state) => state.actions);
 
-export { useFridgeActions, useFridgeStore, useSelectedFridgeId };
+export {
+  useFridgeActions,
+  useFridgeStore,
+  useIsAllFridgeTab,
+  useSelectedFridgeId,
+};


### PR DESCRIPTION
## 작업 내용

- 냉장고 목록에 전체 탭 추가
- 커서 기반 페이지네이션을 활용한 냉장고별 식재료 무한 스크롤 구현
- 식품 추가 시 냉장고 선택 필수 로직 구현(이 전에는 전체라는 탭이 없어 선택된 냉장고에 자동 추가)

## 연관 이슈

- #51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 음식 추가 화면에 등록할 냉장고 선택 UI 추가 및 선택 상태 기반 제출 제어(카테고리 유효성/선택 없으면 제출 차단).
  * 홈 화면에 "전체" 탭 추가로 모든 냉장고의 음식 상태 조회 가능 및 헤더 표기 변경.
  * 냉장고별 음식 목록에 페이지네이션(무한 스크롤) 지원.

* **테스트**
  * 음식 목록/상태 관련 API 및 훅 테스트 추가로 조회·변환 동작 검증 강화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->