### PR TITLE
Feat: 식품 상세 페이지 구현

### DIFF
--- a/app/food/[id].tsx
+++ b/app/food/[id].tsx
@@ -1,0 +1,3 @@
+import { FoodDetailScreen } from "@/features/food-detail/screens/FoodDetailScreen";
+
+export default FoodDetailScreen;

--- a/src/features/food-detail/__tests__/apis/food-detail.test.ts
+++ b/src/features/food-detail/__tests__/apis/food-detail.test.ts
@@ -1,0 +1,10 @@
+import { getFoodDetailApi } from "../../apis/food-detail";
+
+describe("Food Detail API 테스트", () => {
+  it("getFoodDetailApi는 올바른 URL과 메소드로 설정되어야 한다", () => {
+    const api = getFoodDetailApi(123, 456) as any;
+
+    expect(api.endpoint).toBe("/api/v1/refrigerators/123/foods/456");
+    expect(api.method).toBe("GET");
+  });
+});

--- a/src/features/food-detail/__tests__/hooks/useFoodDetailQuery.test.tsx
+++ b/src/features/food-detail/__tests__/hooks/useFoodDetailQuery.test.tsx
@@ -1,0 +1,96 @@
+import apiClient from "@/shared/apis/apiClient";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react-native";
+import React from "react";
+import { useFoodDetailQuery } from "../../hooks/queries/useFoodDetailQuery";
+
+jest.mock("@/shared/apis/apiClient");
+const mockedApiClient = apiClient as jest.MockedFunction<typeof apiClient>;
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false, gcTime: 0 },
+  },
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe("useFoodDetailQuery 테스트", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient.clear();
+  });
+
+  afterAll(() => {
+    queryClient.clear();
+  });
+
+  it("refrigeratorId와 foodId가 있으면 상세 데이터를 성공적으로 가져와야 한다", async () => {
+    const mockData = {
+      result: "SUCCESS",
+      data: {
+        id: 456,
+        refrigeratorId: 123,
+        name: "우유",
+        categoryName: "유제품",
+        description: "유기농 우유",
+        imageURL: "https://example.com/images/milk.jpg",
+        quantity: {
+          amount: 1.5,
+          unit: "L",
+        },
+        condition: {
+          expirationDate: "2026-01-15T00:00:00",
+          storageType: "REFRIGERATION",
+          foodStatus: "GREEN",
+          daysLeft: 7,
+        },
+      },
+    };
+
+    mockedApiClient.mockResolvedValueOnce({ data: mockData });
+
+    const { result } = renderHook(() => useFoodDetailQuery(123, 456), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockData);
+    expect(mockedApiClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "/api/v1/refrigerators/123/foods/456",
+        method: "GET",
+      }),
+    );
+  });
+
+  it("refrigeratorId 또는 foodId가 없으면 쿼리가 실행되지 않아야 한다", () => {
+    const { result } = renderHook(() => useFoodDetailQuery(null, 9), {
+      wrapper,
+    });
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(mockedApiClient).not.toHaveBeenCalled();
+  });
+
+  it("API 호출 실패 시 에러 상태를 반환해야 한다", async () => {
+    mockedApiClient.mockRejectedValueOnce({
+      response: { status: 400, message: "잘못된 요청" },
+    });
+
+    const { result } = renderHook(() => useFoodDetailQuery(3, 9), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBeDefined();
+  });
+});

--- a/src/features/food-detail/apis/food-detail.ts
+++ b/src/features/food-detail/apis/food-detail.ts
@@ -1,0 +1,9 @@
+import ApiBuilder from "@/shared/apis/builder/ApiBuilder";
+import { FoodDetailResponse } from "./food-detail.types";
+
+const getFoodDetailApi = (fridgeId: number, foodId: number) =>
+  ApiBuilder.create<void, FoodDetailResponse>(
+    `/api/v1/refrigerators/${fridgeId}/foods/${foodId}`,
+  ).setMethod("GET");
+
+export { getFoodDetailApi };

--- a/src/features/food-detail/apis/food-detail.types.ts
+++ b/src/features/food-detail/apis/food-detail.types.ts
@@ -1,0 +1,8 @@
+import type { FoodItem } from "@/shared/types/food";
+
+interface FoodDetailResponse {
+  result: string;
+  data: FoodItem;
+}
+
+export type { FoodDetailResponse };

--- a/src/features/food-detail/components/FoodDetail/FoodDetailCard.tsx
+++ b/src/features/food-detail/components/FoodDetail/FoodDetailCard.tsx
@@ -1,0 +1,69 @@
+import {
+  FOOD_STATUS_BG_COLORS,
+  FOOD_STATUS_LABELS,
+  STORAGE_TYPE_LABELS,
+} from "@/shared/constants/food";
+import { getExpiryLabel } from "@/shared/utils/date";
+import { getUnitLabel } from "@/shared/utils/food";
+import { Text, View, XStack, YStack } from "tamagui";
+import { FOOD_STATUS_TEXT } from "../../constants";
+import { FoodDetailCardProps } from "../../types";
+import { FoodDetailCardRow } from "./FoodDetailCardRow";
+
+export function FoodDetailCard({ food }: FoodDetailCardProps) {
+  const statusColor = FOOD_STATUS_LABELS[food.condition.foodStatus];
+  const statusBgColor = FOOD_STATUS_BG_COLORS[food.condition.foodStatus];
+  const expiryLabel = getExpiryLabel(
+    food.condition.expirationDate,
+    food.condition.daysLeft,
+  );
+  const unitLabel = getUnitLabel(food.quantity.unit);
+  const storageLabel = STORAGE_TYPE_LABELS[food.condition.storageType];
+  const statusText = FOOD_STATUS_TEXT[food.condition.foodStatus];
+  const isExpired = food.condition.daysLeft < 0;
+
+  return (
+    <YStack bc="$white" br="$5" p="$4" gap="$3">
+      <YStack gap="$2">
+        <XStack ai="center" jc="space-between" gap="$2">
+          <Text
+            color="$mainText"
+            fontWeight="800"
+            fontSize="$6"
+            fontFamily="$baemin"
+            flex={1}
+          >
+            {food.name}
+          </Text>
+
+          <View px="$3" py="$1" br="$6" bg={statusBgColor}>
+            <Text color={statusColor} fontWeight="700" fontFamily="$baemin">
+              {statusText}
+            </Text>
+          </View>
+        </XStack>
+
+        <Text color="$gray10" fontFamily="$baemin" fontSize="$4">
+          {food.description || "식품 설명이 없습니다."}
+        </Text>
+      </YStack>
+
+      <View h={1} bc="$gray3" />
+
+      <FoodDetailCardRow label="카테고리" value={food.categoryName} />
+      <FoodDetailCardRow label="보관 방식" value={storageLabel} />
+      <FoodDetailCardRow
+        label="수량"
+        value={`${food.quantity.amount} ${unitLabel}`}
+      />
+      <FoodDetailCardRow
+        label="유통기한"
+        value={isExpired ? "기한 만료" : expiryLabel}
+      />
+      <FoodDetailCardRow
+        label="D-Day"
+        value={isExpired ? "만료" : `D-${food.condition.daysLeft}`}
+      />
+    </YStack>
+  );
+}

--- a/src/features/food-detail/components/FoodDetail/FoodDetailCard.tsx
+++ b/src/features/food-detail/components/FoodDetail/FoodDetailCard.tsx
@@ -62,7 +62,13 @@ export function FoodDetailCard({ food }: FoodDetailCardProps) {
       />
       <FoodDetailCardRow
         label="D-Day"
-        value={isExpired ? "만료" : `D-${food.condition.daysLeft}`}
+        value={
+          isExpired
+            ? "만료"
+            : food.condition.daysLeft === 0
+              ? "D-Day"
+              : `D-${food.condition.daysLeft}`
+        }
       />
     </YStack>
   );

--- a/src/features/food-detail/components/FoodDetail/FoodDetailCardRow.tsx
+++ b/src/features/food-detail/components/FoodDetail/FoodDetailCardRow.tsx
@@ -1,0 +1,20 @@
+import { Text, XStack } from "tamagui";
+import { FoodDetailCardRowProps } from "../../types";
+
+export function FoodDetailCardRow({ label, value }: FoodDetailCardRowProps) {
+  return (
+    <XStack jc="space-between" ai="center" py="$3">
+      <Text color="$primary" fontSize="$4" fontFamily="$baemin">
+        {label}
+      </Text>
+      <Text
+        color="$mainText"
+        fontSize="$4"
+        fontWeight="700"
+        fontFamily="$baemin"
+      >
+        {value}
+      </Text>
+    </XStack>
+  );
+}

--- a/src/features/food-detail/components/FoodStatusView.tsx
+++ b/src/features/food-detail/components/FoodStatusView.tsx
@@ -1,0 +1,17 @@
+import { Text, YStack } from "tamagui";
+import { FoodStatusViewProps } from "../types";
+
+export function FoodStatusView({ title, description }: FoodStatusViewProps) {
+  return (
+    <YStack f={1} ai="center" jc="center" px="$6" gap="$3">
+      <Text color="$mainText" fontFamily="$baemin" fontSize="$5" ta="center">
+        {title}
+      </Text>
+      {description ? (
+        <Text color="$gray10" fontFamily="$baemin" fontSize="$4" ta="center">
+          {description}
+        </Text>
+      ) : null}
+    </YStack>
+  );
+}

--- a/src/features/food-detail/components/ImageSection.tsx
+++ b/src/features/food-detail/components/ImageSection.tsx
@@ -1,0 +1,21 @@
+import { Image } from "react-native";
+import { Text, View } from "tamagui";
+import { ImageSectionProps } from "../types";
+
+export function ImageSection({ imageURL }: ImageSectionProps) {
+  return (
+    <View h={220} br="$5" bc="$gray3" ov="hidden" ai="center" jc="center">
+      {imageURL ? (
+        <Image
+          source={{ uri: imageURL }}
+          style={{ width: "100%", height: "100%" }}
+          resizeMode="cover"
+        />
+      ) : (
+        <Text color="$gray10" fontFamily="$baemin">
+          등록된 사진이 없습니다.
+        </Text>
+      )}
+    </View>
+  );
+}

--- a/src/features/food-detail/constants/index.ts
+++ b/src/features/food-detail/constants/index.ts
@@ -1,0 +1,11 @@
+/**
+ * 다른 정보에 유통기한과 d-day가 있어서 상태 텍스트 추가
+ */
+const FOOD_STATUS_TEXT = {
+  GREEN: "안전",
+  YELLOW: "주의",
+  RED: "임박",
+  BLACK: "만료",
+} as const;
+
+export { FOOD_STATUS_TEXT };

--- a/src/features/food-detail/hooks/queries/useFoodDetailQuery.ts
+++ b/src/features/food-detail/hooks/queries/useFoodDetailQuery.ts
@@ -1,0 +1,18 @@
+import { useApiQuery } from "@/shared/apis/builder/ApiBuilder";
+import { QUERY_KEYS } from "@/shared/constants/queryKeys";
+import { getFoodDetailApi } from "../../apis/food-detail";
+
+const useFoodDetailQuery = (
+  refrigeratorId: number | null,
+  foodId: number | null,
+) => {
+  return useApiQuery(
+    getFoodDetailApi(refrigeratorId ?? 0, foodId ?? 0),
+    QUERY_KEYS.food.detail(refrigeratorId ?? 0, foodId ?? 0),
+    {
+      enabled: refrigeratorId !== null && foodId !== null,
+    },
+  );
+};
+
+export { useFoodDetailQuery };

--- a/src/features/food-detail/screens/FoodDetailScreen.tsx
+++ b/src/features/food-detail/screens/FoodDetailScreen.tsx
@@ -1,12 +1,82 @@
+import { Header } from "@/shared/components/Header/Header";
 import { useLocalSearchParams } from "expo-router";
-import { Text, View } from "tamagui";
+import { ScrollView, Spinner, YStack } from "tamagui";
+import { FoodDetailCard } from "../components/FoodDetail/FoodDetailCard";
+import { FoodStatusView } from "../components/FoodStatusView";
+import { ImageSection } from "../components/ImageSection";
+import { useFoodDetailQuery } from "../hooks/queries/useFoodDetailQuery";
+import { parseParamToNumber } from "../utils/params";
 
 export function FoodDetailScreen() {
-  const { id } = useLocalSearchParams();
+  const { id, refrigeratorId } = useLocalSearchParams<{
+    id?: string;
+    refrigeratorId?: string;
+  }>();
+
+  const foodId = parseParamToNumber(id);
+  const targetRefrigeratorId = parseParamToNumber(refrigeratorId);
+
+  const { data: foodDetail, isLoading } = useFoodDetailQuery(
+    targetRefrigeratorId,
+    foodId,
+  );
+
+  const food = foodDetail?.data;
+
+  if (foodId === null) {
+    return (
+      <YStack f={1} backgroundColor="$background">
+        <Header title="식품 상세" showBackButton />
+        <FoodStatusView title="잘못된 식품 경로입니다." />
+      </YStack>
+    );
+  }
+
+  if (targetRefrigeratorId === null) {
+    return (
+      <YStack f={1} backgroundColor="$background">
+        <Header title="식품 상세" showBackButton />
+        <FoodStatusView
+          title="냉장고 정보가 필요해요."
+          description="목록에서 다시 선택해 주세요."
+        />
+      </YStack>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <YStack f={1} backgroundColor="$background">
+        <Header title="식품 상세" showBackButton />
+        <YStack f={1} ai="center" jc="center">
+          <Spinner color="$primary" size="large" />
+        </YStack>
+      </YStack>
+    );
+  }
+
+  if (!food) {
+    return (
+      <YStack f={1} backgroundColor="$background">
+        <Header title="식품 상세" showBackButton />
+        <FoodStatusView
+          title="식품 정보를 불러오지 못했어요."
+          description="잠시 후 다시 시도해 주세요."
+        />
+      </YStack>
+    );
+  }
 
   return (
-    <View f={1} jc="center" ai="center">
-      <Text fontSize="$6">{id}번 식품</Text>
-    </View>
+    <YStack f={1} backgroundColor="$background">
+      <Header title="식품 상세" showBackButton />
+
+      <ScrollView f={1} showsVerticalScrollIndicator={false}>
+        <YStack px="$4" py="$5" gap="$4" pb="$10">
+          <ImageSection imageURL={food.imageURL} />
+          <FoodDetailCard food={food} />
+        </YStack>
+      </ScrollView>
+    </YStack>
   );
 }

--- a/src/features/food-detail/screens/FoodDetailScreen.tsx
+++ b/src/features/food-detail/screens/FoodDetailScreen.tsx
@@ -1,0 +1,12 @@
+import { useLocalSearchParams } from "expo-router";
+import { Text, View } from "tamagui";
+
+export function FoodDetailScreen() {
+  const { id } = useLocalSearchParams();
+
+  return (
+    <View f={1} jc="center" ai="center">
+      <Text fontSize="$6">{id}번 식품</Text>
+    </View>
+  );
+}

--- a/src/features/food-detail/types/index.ts
+++ b/src/features/food-detail/types/index.ts
@@ -1,0 +1,26 @@
+import { FoodItem } from "@/shared/types/food";
+
+interface FoodDetailCardProps {
+  food: FoodItem;
+}
+
+interface FoodDetailCardRowProps {
+  label: string;
+  value: string;
+}
+
+interface FoodStatusViewProps {
+  title: string;
+  description?: string;
+}
+
+interface ImageSectionProps {
+  imageURL?: string;
+}
+
+export {
+  FoodDetailCardProps,
+  FoodDetailCardRowProps,
+  FoodStatusViewProps,
+  ImageSectionProps,
+};

--- a/src/features/food-detail/utils/params.ts
+++ b/src/features/food-detail/utils/params.ts
@@ -1,0 +1,23 @@
+/**
+ * URLSearchParams로부터 전달받은 쿼리 파라미터를 숫자로 변환하는 유틸 함수
+ * useLocalSearchParams 훅에서 반환되는 값은 string | string[] | undefined 형태이므로, 이를 숫자로 안전하게 변환하기 위한 함수입니다.
+ * - string인 경우: 해당 값을 숫자로 변환하여 반환
+ * - string[]인 경우: 배열의 첫 번째 요소를 숫자로 변환하여 반환
+ * - undefined이거나 변환이 불가능한 경우: null 반환
+ * 결론적으로 return 타입은 number | null이 됩니다.
+ */
+
+const parseParamToNumber = (
+  value: string | string[] | undefined,
+): number | null => {
+  const raw = Array.isArray(value) ? value[0] : value;
+  const parsed = Number(raw);
+
+  if (!raw || Number.isNaN(parsed)) {
+    return null;
+  }
+
+  return parsed;
+};
+
+export { parseParamToNumber };

--- a/src/features/home/components/FoodListItem.tsx
+++ b/src/features/home/components/FoodListItem.tsx
@@ -7,7 +7,7 @@ import { getUnitLabel } from "@/shared/utils/food";
 import { Card, Heading, Text, View, XStack, YStack } from "tamagui";
 import { FoodListItemProps } from "../types";
 
-export function FoodListItem({ item }: FoodListItemProps) {
+export function FoodListItem({ item, onPress }: FoodListItemProps) {
   const { foodStatus, expirationDate, daysLeft } = item.condition;
   const statusColor = FOOD_STATUS_LABELS[foodStatus];
   const statusBgColor = FOOD_STATUS_BG_COLORS[foodStatus];
@@ -24,6 +24,8 @@ export function FoodListItem({ item }: FoodListItemProps) {
       mb="$4"
       mx="$4"
       overflow="hidden"
+      onPress={onPress}
+      pressStyle={{ opacity: 0.85 }}
     >
       <XStack p="$4" ai="center" space="$4">
         <View

--- a/src/features/home/hooks/queries/useAllFoodStatusQuery.ts
+++ b/src/features/home/hooks/queries/useAllFoodStatusQuery.ts
@@ -1,10 +1,22 @@
 import { useApiQuery } from "@/shared/apis/builder/ApiBuilder";
 import { QUERY_KEYS } from "@/shared/constants/queryKeys";
 import { getFoodStatusApi } from "../../apis/food";
+import { FoodStatusResponse } from "../../apis/food.types";
+import { normalizeFoodItem } from "../../utils/normalizeFoodItem";
 
 const useAllFoodStatusQuery = (enabled = true) => {
   return useApiQuery(getFoodStatusApi, QUERY_KEYS.food.statusAll(), {
     enabled,
+    select: (response: FoodStatusResponse) => ({
+      ...response,
+      data: {
+        ...response.data,
+        black: response.data.black.map((food) => normalizeFoodItem(food)),
+        red: response.data.red.map((food) => normalizeFoodItem(food)),
+        yellow: response.data.yellow.map((food) => normalizeFoodItem(food)),
+        green: response.data.green.map((food) => normalizeFoodItem(food)),
+      },
+    }),
   });
 };
 

--- a/src/features/home/hooks/queries/useFridgeFoodStatusQuery.ts
+++ b/src/features/home/hooks/queries/useFridgeFoodStatusQuery.ts
@@ -9,6 +9,7 @@ import type {
   FridgeFoodsCursorRequest,
   FridgeFoodsResponseRaw,
 } from "../../apis/food.types";
+import { normalizeFoodItem } from "../../utils/normalizeFoodItem";
 
 const DEFAULT_CURSOR_REQUEST: FridgeFoodsCursorRequest = {
   size: 50,
@@ -126,7 +127,9 @@ const useFridgeFoodStatusQuery = (
 
     const allFoods: FoodItem[] = [];
     query.data.pages.forEach((page: any) => {
-      const foods = extractFoods(page.data);
+      const foods = extractFoods(page.data).map((food) =>
+        normalizeFoodItem(food, fridgeId ?? undefined),
+      );
       allFoods.push(...foods);
     });
 
@@ -135,7 +138,7 @@ const useFridgeFoodStatusQuery = (
       result: "SUCCESS",
       data: groupFoodsByStatus(allFoods),
     };
-  }, [query.data?.pages]);
+  }, [fridgeId, query.data?.pages]);
 
   const hasMore = query.hasNextPage ?? false;
 

--- a/src/features/home/screens/HomeScreen.tsx
+++ b/src/features/home/screens/HomeScreen.tsx
@@ -5,6 +5,7 @@ import {
   useSelectedFridgeId,
 } from "@/shared/stores/useFridgeStore";
 import { FlashList } from "@shopify/flash-list";
+import { useRouter } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
 import { View } from "react-native";
 import { Text, XStack, YStack } from "tamagui";
@@ -20,6 +21,7 @@ import { useFridgeQuery } from "../hooks/queries/useFridgeQuery";
 import { FoodStatus, SortOption } from "../types";
 
 export function HomeScreen() {
+  const router = useRouter();
   const { data: fridgeData, isLoading: isFridgeLoading } = useFridgeQuery();
   const selectedFridgeId = useSelectedFridgeId();
   const isAllFridgeTab = useIsAllFridgeTab();
@@ -178,7 +180,17 @@ export function HomeScreen() {
       <View style={{ flex: 1, width: "100%" }}>
         <FlashList
           data={sortedAndFilteredFoods}
-          renderItem={({ item }) => <FoodListItem item={item} />}
+          renderItem={({ item }) => (
+            <FoodListItem
+              item={item}
+              onPress={() =>
+                router.push({
+                  pathname: "/food/[id]",
+                  params: { id: item.id },
+                })
+              }
+            />
+          )}
           keyExtractor={(item) => item.id.toString()}
           //@ts-ignore
           contentContainerStyle={{ paddingBottom: 40 }}

--- a/src/features/home/screens/HomeScreen.tsx
+++ b/src/features/home/screens/HomeScreen.tsx
@@ -183,12 +183,20 @@ export function HomeScreen() {
           renderItem={({ item }) => (
             <FoodListItem
               item={item}
-              onPress={() =>
+              onPress={() => {
+                const targetRefrigeratorId =
+                  item.refrigeratorId ?? selectedFridgeId ?? undefined;
+
                 router.push({
                   pathname: "/food/[id]",
-                  params: { id: item.id },
-                })
-              }
+                  params: {
+                    id: item.id.toString(),
+                    ...(targetRefrigeratorId !== undefined
+                      ? { refrigeratorId: targetRefrigeratorId.toString() }
+                      : {}),
+                  },
+                } as any);
+              }}
             />
           )}
           keyExtractor={(item) => item.id.toString()}

--- a/src/features/home/types/index.ts
+++ b/src/features/home/types/index.ts
@@ -34,6 +34,7 @@ interface FridgeTabScrollProps {
 
 interface FoodListItemProps {
   item: FoodItem;
+  onPress?: () => void;
 }
 
 type CategoryTabType = (typeof STORAGE_TABS)[number];

--- a/src/features/home/utils/normalizeFoodItem.ts
+++ b/src/features/home/utils/normalizeFoodItem.ts
@@ -57,7 +57,7 @@ const normalizeFoodItem = (
   fallbackRefrigeratorId?: number,
 ): FoodItem => {
   const normalizedRefrigeratorId =
-    extractRefrigeratorId(food) ?? fallbackRefrigeratorId;
+    extractRefrigeratorId(food) ?? toValidNumber(fallbackRefrigeratorId);
 
   if (normalizedRefrigeratorId === undefined) {
     return food;

--- a/src/features/home/utils/normalizeFoodItem.ts
+++ b/src/features/home/utils/normalizeFoodItem.ts
@@ -1,0 +1,72 @@
+/**
+ * 전체 탭에서 식품 상세 조회페이지로 이동을 위해 냉장고 id를 추출하는 유틸함수
+ */
+
+import { FoodItem } from "@/shared/types/food";
+
+const toValidNumber = (value: unknown): number | undefined => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return undefined;
+};
+
+const extractRefrigeratorId = (food: FoodItem): number | undefined => {
+  const candidateFromDirect = toValidNumber(food.refrigeratorId);
+  if (candidateFromDirect !== undefined) {
+    return candidateFromDirect;
+  }
+
+  const rawFood = food as FoodItem & {
+    fridgeId?: unknown;
+    refrigerator?: { id?: unknown; refrigeratorId?: unknown };
+  };
+
+  const candidateFromFridgeId = toValidNumber(rawFood.fridgeId);
+  if (candidateFromFridgeId !== undefined) {
+    return candidateFromFridgeId;
+  }
+
+  const candidateFromRefrigeratorId = toValidNumber(
+    rawFood.refrigerator?.refrigeratorId,
+  );
+  if (candidateFromRefrigeratorId !== undefined) {
+    return candidateFromRefrigeratorId;
+  }
+
+  const candidateFromRefrigeratorObjectId = toValidNumber(
+    rawFood.refrigerator?.id,
+  );
+  if (candidateFromRefrigeratorObjectId !== undefined) {
+    return candidateFromRefrigeratorObjectId;
+  }
+
+  return undefined;
+};
+
+const normalizeFoodItem = (
+  food: FoodItem,
+  fallbackRefrigeratorId?: number,
+): FoodItem => {
+  const normalizedRefrigeratorId =
+    extractRefrigeratorId(food) ?? fallbackRefrigeratorId;
+
+  if (normalizedRefrigeratorId === undefined) {
+    return food;
+  }
+
+  return {
+    ...food,
+    refrigeratorId: normalizedRefrigeratorId,
+  };
+};
+
+export { normalizeFoodItem };

--- a/src/shared/constants/queryKeys.ts
+++ b/src/shared/constants/queryKeys.ts
@@ -16,6 +16,8 @@ const QUERY_KEYS = {
       [...QUERY_KEYS.food.all, "status", fridgeId] as const,
     statusByRefrigerator: (fridgeId: number) =>
       [...QUERY_KEYS.food.all, "statusByRefrigerator", fridgeId] as const,
+    detail: (fridgeId: number, foodId: number) =>
+      [...QUERY_KEYS.food.all, "detail", fridgeId, foodId] as const,
   },
   notification: {
     all: ["notifications"] as const,

--- a/src/shared/types/food.ts
+++ b/src/shared/types/food.ts
@@ -3,8 +3,10 @@ type StorageType = "REFRIGERATION" | "FROZEN" | "ROOM_TEMPERATURE";
 
 interface FoodItem {
   id: number;
+  refrigeratorId?: number;
   name: string;
   categoryName: string;
+  description?: string;
   imageURL?: string;
   quantity: {
     amount: number;


### PR DESCRIPTION
## 작업 내용

- 식품 상세 페이지 구현
- 식품 타입에 냉장고Id 및 설명 추가
- 냉장고 Id를 추가한 식품 정규화 유틸 함수 구현 및 적용

## 연관 이슈

- #53


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 식품 상세 페이지 추가 — 이미지 영역, 상태 배지, 설명, 보관방법, 수량, 유통기한 및 D-Day 표시
  * 상세 페이지로 이동 가능한 목록 항목의 탭(press) 동작 및 시각 피드백 추가

* **개선사항**
  * 식품 데이터 모델에 설명·냉장고 ID 필드 추가 및 항목 정규화로 일관된 표시 개선
  * 상태 레이블·상태 뷰·카드 구성요소 등 시각 구성 개선
  * URL/쿼리 파라미터 파싱 및 조회 훅의 안전성 향상

* **테스트**
  * 식품 상세 API 및 훅에 대한 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->