### PR TITLE
Feat: 식재료 삭제 기능 구현

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -26,6 +26,7 @@ import {
   getMessaging,
   setBackgroundMessageHandler,
 } from "@react-native-firebase/messaging";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 
 if (__DEV__) {
   require("../ReactotronConfig");
@@ -90,36 +91,40 @@ export default function RootLayout() {
 
   if (!isAppReady || !animationFinished) {
     return (
-      <View style={{ flex: 1 }} onLayout={onLayoutRootView}>
-        <AnimatedSplashScreen
-          onAnimationFinish={() => {
-            hasShownAnimatedSplash = true;
-            setAnimationFinished(true);
-          }}
-        />
-      </View>
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <View style={{ flex: 1 }} onLayout={onLayoutRootView}>
+          <AnimatedSplashScreen
+            onAnimationFinish={() => {
+              hasShownAnimatedSplash = true;
+              setAnimationFinished(true);
+            }}
+          />
+        </View>
+      </GestureHandlerRootView>
     );
   }
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <SafeAreaProvider>
-        <TamaguiProvider config={config} defaultTheme="light">
-          {/* 세션 관리 로직을 위해 스택 위에 배치 */}
-          <SessionProvider />
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <QueryClientProvider client={queryClient}>
+        <SafeAreaProvider>
+          <TamaguiProvider config={config} defaultTheme="light">
+            {/* 세션 관리 로직을 위해 스택 위에 배치 */}
+            <SessionProvider />
 
-          <Stack screenOptions={{ headerShown: false }}>
-            <Stack.Screen name="(tabs)" />
-            <Stack.Screen name="(auth)" />
-            <Stack.Screen
-              name="modal"
-              options={{ presentation: "modal", title: "Modal" }}
-            />
-          </Stack>
-          <StatusBar style="auto" />
-          <Toast config={toastConfig} />
-        </TamaguiProvider>
-      </SafeAreaProvider>
-    </QueryClientProvider>
+            <Stack screenOptions={{ headerShown: false }}>
+              <Stack.Screen name="(tabs)" />
+              <Stack.Screen name="(auth)" />
+              <Stack.Screen
+                name="modal"
+                options={{ presentation: "modal", title: "Modal" }}
+              />
+            </Stack>
+            <StatusBar style="auto" />
+            <Toast config={toastConfig} />
+          </TamaguiProvider>
+        </SafeAreaProvider>
+      </QueryClientProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/src/features/home/__tests__/apis/food.test.ts
+++ b/src/features/home/__tests__/apis/food.test.ts
@@ -1,4 +1,8 @@
-import { getFoodStatusApi, getFridgeFoodsApi } from "../../apis/food";
+import {
+  deleteFoodApi,
+  getFoodStatusApi,
+  getFridgeFoodsApi,
+} from "../../apis/food";
 
 describe("Food API 테스트", () => {
   it("getFoodStatusApi는 올바른 URL과 메소드로 설정되어야 한다", () => {
@@ -19,5 +23,12 @@ describe("Food API 테스트", () => {
       size: 50,
       sortBy: "EXPIRATION",
     });
+  });
+
+  it("deleteFoodApi는 올바른 URL과 메소드로 올바르게 설정되어야 한다", () => {
+    const api = deleteFoodApi(123, 456) as any;
+
+    expect(api.endpoint).toBe("/api/v1/refrigerators/123/foods/456");
+    expect(api.method).toBe("DELETE");
   });
 });

--- a/src/features/home/__tests__/hooks/useDeleteFoodMutation.test.tsx
+++ b/src/features/home/__tests__/hooks/useDeleteFoodMutation.test.tsx
@@ -1,0 +1,98 @@
+import apiClient from "@/shared/apis/apiClient";
+import { QUERY_KEYS } from "@/shared/constants/queryKeys";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react-native";
+import React from "react";
+import Toast from "react-native-toast-message";
+import { useDeleteFoodMutation } from "../../hooks/mutations/useDeleteFoodMutation";
+
+jest.mock("@/shared/apis/apiClient");
+jest.mock("react-native-toast-message", () => ({ show: jest.fn() }));
+
+const mockedApiClient = apiClient as jest.MockedFunction<typeof apiClient>;
+const mockedToast = Toast.show as jest.Mock;
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false },
+    mutations: { retry: false },
+  },
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe("useDeleteFoodMutation 테스트", () => {
+  const TEST_FRIDGE_ID = 123;
+  const TEST_FOOD_ID = 456;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient.clear();
+  });
+
+  it("식품 삭제 성공 시 API 호출, 쿼리 무효화, 캐시 제거, 성공 토스트를 실행해야 한다", async () => {
+    mockedApiClient.mockResolvedValueOnce({
+      data: { result: "SUCCESS" },
+    } as any);
+    const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+    const removeSpy = jest.spyOn(queryClient, "removeQueries");
+
+    const { result } = renderHook(() => useDeleteFoodMutation(), {
+      wrapper,
+    });
+
+    result.current.mutate({ fridgeId: TEST_FRIDGE_ID, foodId: TEST_FOOD_ID });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockedApiClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "DELETE",
+        url: `/api/v1/refrigerators/${TEST_FRIDGE_ID}/foods/${TEST_FOOD_ID}`,
+      }),
+    );
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: QUERY_KEYS.food.all }),
+    );
+
+    expect(removeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: QUERY_KEYS.food.detail(TEST_FRIDGE_ID, TEST_FOOD_ID),
+      }),
+    );
+
+    expect(mockedToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "success",
+        text1: "식품 삭제 완료",
+      }),
+    );
+  });
+
+  it("식품 삭제 실패 시 서버 에러 메시지 토스트를 표시해야 한다", async () => {
+    const SERVER_ERROR_MSG = "삭제 권한이 없습니다.";
+
+    mockedApiClient.mockRejectedValueOnce({
+      response: { data: { error: { message: SERVER_ERROR_MSG } } },
+    });
+
+    const { result } = renderHook(() => useDeleteFoodMutation(), {
+      wrapper,
+    });
+
+    result.current.mutate({ fridgeId: TEST_FRIDGE_ID, foodId: TEST_FOOD_ID });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(mockedToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "error",
+        text1: "삭제 실패",
+        text2: SERVER_ERROR_MSG,
+      }),
+    );
+  });
+});

--- a/src/features/home/apis/food.ts
+++ b/src/features/home/apis/food.ts
@@ -19,4 +19,9 @@ const getFridgeFoodsApi = (
     .setMethod("GET")
     .setParams(cursorRequest);
 
-export { getFoodStatusApi, getFridgeFoodsApi };
+const deleteFoodApi = (fridgeId: number, foodId: number) =>
+  ApiBuilder.create<void, void>(
+    `/api/v1/refrigerators/${fridgeId}/foods/${foodId}`,
+  ).setMethod("DELETE");
+
+export { deleteFoodApi, getFoodStatusApi, getFridgeFoodsApi };

--- a/src/features/home/components/FoodListItem/FoodListItem.tsx
+++ b/src/features/home/components/FoodListItem/FoodListItem.tsx
@@ -5,7 +5,7 @@ import {
 import { getExpiryLabel } from "@/shared/utils/date";
 import { getUnitLabel } from "@/shared/utils/food";
 import { Card, Heading, Text, View, XStack, YStack } from "tamagui";
-import { FoodListItemProps } from "../types";
+import { FoodListItemProps } from "../../types";
 
 export function FoodListItem({ item, onPress }: FoodListItemProps) {
   const { foodStatus, expirationDate, daysLeft } = item.condition;

--- a/src/features/home/components/FoodListItem/SwipeableFoodListItem.tsx
+++ b/src/features/home/components/FoodListItem/SwipeableFoodListItem.tsx
@@ -1,0 +1,55 @@
+import { Trash2 } from "@tamagui/lucide-icons";
+import { ComponentRef, useRef } from "react";
+import ReanimatedSwipeable from "react-native-gesture-handler/ReanimatedSwipeable";
+import { Button, Text, View, YStack } from "tamagui";
+import { SwipeableFoodListItemProps } from "../../types";
+import { FoodListItem } from "./FoodListItem";
+
+export function SwipeableFoodListItem({
+  item,
+  onPress,
+  onDelete,
+  isDeleting = false,
+}: SwipeableFoodListItemProps) {
+  const swipeableRef = useRef<ComponentRef<typeof ReanimatedSwipeable>>(null);
+
+  const renderRightActions = () => {
+    return (
+      <View width={80} mr="$4" mb="$4" jc="center">
+        <Button
+          f={1}
+          bg="$warning"
+          borderRadius="$4"
+          disabled={isDeleting}
+          onPress={() => {
+            swipeableRef.current?.close();
+            if (onDelete) {
+              onDelete(item.id);
+            }
+          }}
+          pressStyle={{ opacity: 0.7 }}
+        >
+          <YStack gap="$1" ai="center" jc="center">
+            <Trash2 size="$2" color="$white" />
+            <Text color="$white" fontSize={11} fontWeight="700">
+              삭제
+            </Text>
+          </YStack>
+        </Button>
+      </View>
+    );
+  };
+
+  return (
+    <ReanimatedSwipeable
+      ref={swipeableRef}
+      renderRightActions={renderRightActions}
+      overshootRight={false}
+      friction={2}
+      leftThreshold={30}
+      rightThreshold={10}
+    >
+      <FoodListItem item={item} onPress={onPress} />
+    </ReanimatedSwipeable>
+  );
+}

--- a/src/features/home/hooks/mutations/useDeleteFoodMutation.tsx
+++ b/src/features/home/hooks/mutations/useDeleteFoodMutation.tsx
@@ -1,0 +1,48 @@
+import { QUERY_KEYS } from "@/shared/constants/queryKeys";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import Toast from "react-native-toast-message";
+import { deleteFoodApi } from "../../apis/food";
+
+interface DeleteFoodVariables {
+  fridgeId: number;
+  foodId: number;
+}
+
+const useDeleteFoodMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, any, DeleteFoodVariables>({
+    // 요청 받는 시점에 실행
+    mutationFn: async ({ fridgeId, foodId }) => {
+      await deleteFoodApi(fridgeId, foodId).execute();
+    },
+    onSuccess: (_data, variables) => {
+      const { fridgeId, foodId } = variables;
+
+      queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.food.all,
+      });
+
+      queryClient.removeQueries({
+        queryKey: QUERY_KEYS.food.detail(fridgeId, foodId),
+      });
+
+      Toast.show({
+        type: "success",
+        text1: "식품 삭제 완료",
+        text2: "식품이 성공적으로 삭제되었습니다.",
+      });
+    },
+    onError: (error: any) => {
+      const serverMessage = error.response?.data?.error?.message;
+
+      Toast.show({
+        type: "error",
+        text1: "삭제 실패",
+        text2: serverMessage || "식품 삭제 중 오류가 발생했습니다.",
+      });
+    },
+  });
+};
+
+export { useDeleteFoodMutation };

--- a/src/features/home/hooks/mutations/useDeleteFoodMutation.tsx
+++ b/src/features/home/hooks/mutations/useDeleteFoodMutation.tsx
@@ -1,5 +1,9 @@
 import { QUERY_KEYS } from "@/shared/constants/queryKeys";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  UseMutationOptions,
+  useQueryClient,
+} from "@tanstack/react-query";
 import Toast from "react-native-toast-message";
 import { deleteFoodApi } from "../../apis/food";
 
@@ -8,7 +12,9 @@ interface DeleteFoodVariables {
   foodId: number;
 }
 
-const useDeleteFoodMutation = () => {
+const useDeleteFoodMutation = (
+  options?: UseMutationOptions<void, any, DeleteFoodVariables>,
+) => {
   const queryClient = useQueryClient();
 
   return useMutation<void, any, DeleteFoodVariables>({
@@ -16,7 +22,7 @@ const useDeleteFoodMutation = () => {
     mutationFn: async ({ fridgeId, foodId }) => {
       await deleteFoodApi(fridgeId, foodId).execute();
     },
-    onSuccess: (_data, variables) => {
+    onSuccess: (data, variables, onMutateResult, context) => {
       const { fridgeId, foodId } = variables;
 
       queryClient.invalidateQueries({
@@ -32,8 +38,10 @@ const useDeleteFoodMutation = () => {
         text1: "식품 삭제 완료",
         text2: "식품이 성공적으로 삭제되었습니다.",
       });
+
+      options?.onSuccess?.(data, variables, onMutateResult, context);
     },
-    onError: (error: any) => {
+    onError: (error: any, variables, onMutateResult, context) => {
       const serverMessage = error.response?.data?.error?.message;
 
       Toast.show({
@@ -41,6 +49,11 @@ const useDeleteFoodMutation = () => {
         text1: "삭제 실패",
         text2: serverMessage || "식품 삭제 중 오류가 발생했습니다.",
       });
+
+      options?.onError?.(error, variables, onMutateResult, context);
+    },
+    onSettled: (data, error, variables, onMutateResult, context) => {
+      options?.onSettled?.(data, error, variables, onMutateResult, context);
     },
   });
 };

--- a/src/features/home/screens/HomeScreen.tsx
+++ b/src/features/home/screens/HomeScreen.tsx
@@ -254,9 +254,6 @@ export function HomeScreen() {
         open={isDeleteConfirmOpen}
         onOpenChange={(open) => {
           setIsDeleteConfirmOpen(open);
-          if (!open && !isDeletePending) {
-            setDeleteTarget(null);
-          }
         }}
         title="정말 삭제하시겠습니까?"
         description={
@@ -269,8 +266,6 @@ export function HomeScreen() {
           if (!deleteTarget || isDeletePending) {
             return;
           }
-
-          setIsDeleteConfirmOpen(false);
 
           deleteFood({
             fridgeId: deleteTarget.fridgeId,

--- a/src/features/home/screens/HomeScreen.tsx
+++ b/src/features/home/screens/HomeScreen.tsx
@@ -198,7 +198,9 @@ export function HomeScreen() {
             <SwipeableFoodListItem
               item={item}
               onDelete={() => {
-                const targetFridgeId = item.refrigeratorId ?? selectedFridgeId;
+                const targetFridgeId =
+                  item.refrigeratorId ||
+                  (!isAllFridgeTab ? selectedFridgeId : null);
                 if (!targetFridgeId) {
                   return;
                 }

--- a/src/features/home/screens/HomeScreen.tsx
+++ b/src/features/home/screens/HomeScreen.tsx
@@ -73,7 +73,11 @@ export function HomeScreen() {
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
 
   const { mutate: deleteFood, isPending: isDeletePending } =
-    useDeleteFoodMutation();
+    useDeleteFoodMutation({
+      onSettled: () => {
+        setDeleteTarget(null);
+      },
+    });
 
   const allFoods = useMemo(() => {
     if (!foodStatusData?.data) return [];
@@ -250,7 +254,7 @@ export function HomeScreen() {
         open={isDeleteConfirmOpen}
         onOpenChange={(open) => {
           setIsDeleteConfirmOpen(open);
-          if (!open) {
+          if (!open && !isDeletePending) {
             setDeleteTarget(null);
           }
         }}
@@ -262,9 +266,12 @@ export function HomeScreen() {
         }
         confirmText="삭제"
         onConfirm={() => {
-          if (!deleteTarget) {
+          if (!deleteTarget || isDeletePending) {
             return;
           }
+
+          setIsDeleteConfirmOpen(false);
+
           deleteFood({
             fridgeId: deleteTarget.fridgeId,
             foodId: deleteTarget.foodId,

--- a/src/features/home/screens/HomeScreen.tsx
+++ b/src/features/home/screens/HomeScreen.tsx
@@ -1,4 +1,5 @@
 import { Header } from "@/shared/components/Header/Header";
+import { ConfirmModal } from "@/shared/components/Modal/ConfirmModal";
 import {
   useFridgeActions,
   useIsAllFridgeTab,
@@ -11,14 +12,22 @@ import { View } from "react-native";
 import { Text, XStack, YStack } from "tamagui";
 import { CategoryTabs } from "../components/CategoryTabs";
 import { Expiry } from "../components/Expiry/Expiry";
-import { FoodListItem } from "../components/FoodListItem";
+import { SwipeableFoodListItem } from "../components/FoodListItem/SwipeableFoodListItem";
 import { FridgeTabScroll } from "../components/FridgeTabScroll";
 import { HomeSkeleton } from "../components/HomeSkeleton";
 import { SortFilter } from "../components/SortFilter";
+import { useDeleteFoodMutation } from "../hooks/mutations/useDeleteFoodMutation";
 import { useAllFoodStatusQuery } from "../hooks/queries/useAllFoodStatusQuery";
 import { useFridgeFoodStatusQuery } from "../hooks/queries/useFridgeFoodStatusQuery";
 import { useFridgeQuery } from "../hooks/queries/useFridgeQuery";
 import { FoodStatus, SortOption } from "../types";
+
+interface DeleteTarget {
+  // foodName은 삭제 확인 모달에 표시할지 말지 고민
+  fridgeId: number;
+  foodId: number;
+  // foodName: string;
+}
 
 export function HomeScreen() {
   const router = useRouter();
@@ -60,6 +69,11 @@ export function HomeScreen() {
   const [sortOption, setSortOption] = useState<SortOption>("EXPIRY_ASC");
   const [selectedCategory, setSelectedCategory] = useState("전체");
   const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
+
+  const { mutate: deleteFood, isPending: isDeletePending } =
+    useDeleteFoodMutation();
 
   const allFoods = useMemo(() => {
     if (!foodStatusData?.data) return [];
@@ -181,8 +195,22 @@ export function HomeScreen() {
         <FlashList
           data={sortedAndFilteredFoods}
           renderItem={({ item }) => (
-            <FoodListItem
+            <SwipeableFoodListItem
               item={item}
+              onDelete={() => {
+                const targetFridgeId = item.refrigeratorId ?? selectedFridgeId;
+                if (!targetFridgeId) {
+                  return;
+                }
+
+                setDeleteTarget({
+                  fridgeId: targetFridgeId,
+                  foodId: item.id,
+                  // foodName: item.name,
+                });
+                setIsDeleteConfirmOpen(true);
+              }}
+              isDeleting={isDeletePending && deleteTarget?.foodId === item.id}
               onPress={() => {
                 const targetRefrigeratorId =
                   item.refrigeratorId ?? selectedFridgeId ?? undefined;
@@ -215,6 +243,33 @@ export function HomeScreen() {
           }
         />
       </View>
+
+      <ConfirmModal
+        open={isDeleteConfirmOpen}
+        onOpenChange={(open) => {
+          setIsDeleteConfirmOpen(open);
+          if (!open) {
+            setDeleteTarget(null);
+          }
+        }}
+        title="정말 삭제하시겠습니까?"
+        description={
+          deleteTarget
+            ? `삭제된 식품은 복구할 수 없습니다. 신중하게 선택해 주세요.`
+            : "선택한 식품을 삭제하시겠어요?"
+        }
+        confirmText="삭제"
+        onConfirm={() => {
+          if (!deleteTarget) {
+            return;
+          }
+          deleteFood({
+            fridgeId: deleteTarget.fridgeId,
+            foodId: deleteTarget.foodId,
+          });
+        }}
+        confirmColor="$warning"
+      />
 
       <SortFilter
         visible={isFilterOpen}

--- a/src/features/home/types/index.ts
+++ b/src/features/home/types/index.ts
@@ -37,6 +37,11 @@ interface FoodListItemProps {
   onPress?: () => void;
 }
 
+interface SwipeableFoodListItemProps extends FoodListItemProps {
+  onDelete?: (foodId: number) => void;
+  isDeleting?: boolean;
+}
+
 type CategoryTabType = (typeof STORAGE_TABS)[number];
 
 interface CategoryTabsProps {
@@ -64,4 +69,5 @@ export {
   SortFilterProps,
   SortOption,
   StatusItemProps,
+  SwipeableFoodListItemProps,
 };


### PR DESCRIPTION
## 작업 내용

- 식재료 아이템 스와이프 제스처 구현
- 식재료 삭제 기능 구현
- 식재료 삭제 기능 테스트 구현

## 연관 이슈

- #57


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 음식 항목을 오른쪽으로 스와이프해 삭제할 수 있는 항목 UI와 삭제 훅 및 관련 확인 모달 추가

* **테스트**
  * 삭제 API 엔드포인트 검증 테스트 추가
  * 삭제 훅의 성공·실패 흐름을 검증하는 단위 테스트 추가

* **개선사항**
  * 루트 레벨 제스처 처리 강화로 스와이프 경험 개선
  * 삭제 시 목록 및 상세 캐시가 갱신되어 UI 일관성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->