### PR TITLE
Feat: 검색 및 캘린더 페이지 내 식재료 상세 라우팅 구현 

### DIFF
--- a/src/features/calendar/components/CalendarFoodList.tsx
+++ b/src/features/calendar/components/CalendarFoodList.tsx
@@ -11,6 +11,7 @@ import {
 export function CalendarFoodList({
   selectedDate,
   foods,
+  onPress,
 }: CalendarFoodListProps) {
   const selectedDateLabel = getSelectedDateLabel(selectedDate);
 
@@ -41,6 +42,8 @@ export function CalendarFoodList({
                 py="$4"
                 bc="$gray4"
                 backgroundColor="$background"
+                onPress={() => onPress?.(food)}
+                pressStyle={{ opacity: 0.85 }}
               >
                 <XStack ai="center" gap="$3" f={1}>
                   <View

--- a/src/features/calendar/screens/CalendarScreen.tsx
+++ b/src/features/calendar/screens/CalendarScreen.tsx
@@ -1,6 +1,7 @@
 import { Header } from "@/shared/components/Header/Header";
 import { useSelectedFridgeId } from "@/shared/stores/useFridgeStore";
 import { FoodItem } from "@/shared/types/food";
+import { useRouter } from "expo-router";
 import React, { useMemo, useState } from "react";
 import { YStack } from "tamagui";
 import { useFoodStatusQuery } from "../../home/hooks/queries/useFoodStatusQuery";
@@ -21,6 +22,7 @@ const getLocalDateString = () => {
 };
 
 export function CalendarScreen() {
+  const router = useRouter();
   const selectedFridgeId = useSelectedFridgeId();
 
   const [selectedDate, setSelectedDate] = useState(() => getLocalDateString());
@@ -60,6 +62,20 @@ export function CalendarScreen() {
       <CalendarFoodList
         selectedDate={selectedDate}
         foods={foodsOnSelectedDate}
+        onPress={(food) => {
+          const targetRefrigeratorId =
+            food.refrigeratorId ?? selectedFridgeId ?? undefined;
+
+          router.push({
+            pathname: "/food/[id]",
+            params: {
+              id: food.id.toString(),
+              ...(targetRefrigeratorId !== undefined
+                ? { refrigeratorId: targetRefrigeratorId.toString() }
+                : {}),
+            },
+          } as any);
+        }}
       />
     </YStack>
   );

--- a/src/features/calendar/types/index.ts
+++ b/src/features/calendar/types/index.ts
@@ -9,6 +9,7 @@ interface CalendarMonthViewProps {
 interface CalendarFoodListProps {
   selectedDate: string;
   foods: FoodItem[];
+  onPress?: (food: FoodItem) => void;
 }
 
 export { CalendarFoodListProps, CalendarMonthViewProps };

--- a/src/features/search/components/SearchResultItem.tsx
+++ b/src/features/search/components/SearchResultItem.tsx
@@ -3,9 +3,10 @@ import { Image, Text, View, XStack, YStack } from "tamagui";
 
 interface Props {
   item: FoodItem;
+  onPress?: () => void;
 }
 
-export function SearchResultItem({ item }: Props) {
+export function SearchResultItem({ item, onPress }: Props) {
   const statusColors = {
     GREEN: "$success",
     YELLOW: "$alert",
@@ -17,7 +18,15 @@ export function SearchResultItem({ item }: Props) {
     item.condition.foodStatus === "BLACK" || item.condition.daysLeft < 0;
 
   return (
-    <XStack ai="center" py="$3" px="$4" gap="$3" backgroundColor="$background">
+    <XStack
+      ai="center"
+      py="$3"
+      px="$4"
+      gap="$3"
+      backgroundColor="$background"
+      onPress={onPress}
+      pressStyle={{ opacity: 0.8 }}
+    >
       <View
         w={50}
         h={50}

--- a/src/features/search/screens/SearchScreen.tsx
+++ b/src/features/search/screens/SearchScreen.tsx
@@ -1,5 +1,7 @@
+import { useSelectedFridgeId } from "@/shared/stores/useFridgeStore";
 import { FlashList } from "@shopify/flash-list";
 import { Search as SearchIcon, X } from "@tamagui/lucide-icons";
+import { useRouter } from "expo-router";
 import { useState } from "react";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Button, Input, Text, View, XStack, YStack } from "tamagui";
@@ -7,6 +9,8 @@ import { SearchResultItem } from "../components/SearchResultItem";
 import { useSearchFood } from "../hooks/useSearchFood";
 
 export function SearchScreen() {
+  const router = useRouter();
+  const selectedFridgeId = useSelectedFridgeId();
   const [searchQuery, setSearchQuery] = useState("");
   const { filteredResult } = useSearchFood(searchQuery);
 
@@ -59,7 +63,25 @@ export function SearchScreen() {
         <View f={1} width="100%">
           <FlashList
             data={filteredResult}
-            renderItem={({ item }) => <SearchResultItem item={item} />}
+            renderItem={({ item }) => (
+              <SearchResultItem
+                item={item}
+                onPress={() => {
+                  const targetRefrigeratorId =
+                    item.refrigeratorId ?? selectedFridgeId ?? undefined;
+
+                  router.push({
+                    pathname: "/food/[id]",
+                    params: {
+                      id: item.id.toString(),
+                      ...(targetRefrigeratorId !== undefined
+                        ? { refrigeratorId: targetRefrigeratorId.toString() }
+                        : {}),
+                    },
+                  } as any);
+                }}
+              />
+            )}
             keyExtractor={(item) => item.id.toString()}
             ItemSeparatorComponent={() => (
               <View backgroundColor="$gray3" mx="$4" height={1} />


### PR DESCRIPTION
## 작업 내용

- 검색 페이지에서 식재료 상세페이지 라우팅 구현
- 캘린더 페이지에서 식재료 상세페이지 라우팅 구현

## 연관 이슈

- #59 

## 참고 사항
- 식재료 api 명세에 냉장고id 값이 추가됐을때 수정 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 달력 및 검색 결과의 식품 항목을 탭하여 상세 정보 페이지로 이동할 수 있도록 개선
  * 식품 항목 선택 시 시각적 피드백(투명도 효과) 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->