### PR TITLE
Chore: 컴포넌트 명 Modal ->Sheet로 변경

### DIFF
--- a/src/features/food-add/components/CategorySelector/CategoryAddSheet.tsx
+++ b/src/features/food-add/components/CategorySelector/CategoryAddSheet.tsx
@@ -17,14 +17,14 @@ import {
   XStack,
   YStack,
 } from "tamagui";
-import { CategoryAddFormValues, CategoryAddModalProps } from "../../types";
+import { CategoryAddFormValues, CategoryAddSheetProps } from "../../types";
 
-export const CategoryAddModal = ({
+export const CategoryAddSheet = ({
   visible,
   onClose,
   onAdd,
   isPending = false,
-}: CategoryAddModalProps) => {
+}: CategoryAddSheetProps) => {
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
 
   const {

--- a/src/features/food-add/components/CategorySelector/CategorySelector.tsx
+++ b/src/features/food-add/components/CategorySelector/CategorySelector.tsx
@@ -4,7 +4,7 @@ import { Controller } from "react-hook-form";
 import { Button, ScrollView, Text, XStack, YStack, styled } from "tamagui";
 import { useAddCategoryMutation } from "../../hooks/mutations/useAddCategoryMutation";
 import { CategorySelectorProps } from "../../types";
-import { CategoryAddModal } from "./CategoryAddModal";
+import { CategoryAddSheet } from "./CategoryAddSheet";
 
 const LabelText = styled(Text, { fontSize: 18, fontWeight: "700", mb: "$2" });
 
@@ -72,7 +72,7 @@ export const CategorySelector = ({
               </Button>
             </XStack>
           </ScrollView>
-          <CategoryAddModal
+          <CategoryAddSheet
             visible={isAddModalOpen}
             onClose={closeModal}
             onAdd={handleAddCategory}

--- a/src/features/food-add/components/ExpiryDatePicker/DateSelectSheet.tsx
+++ b/src/features/food-add/components/ExpiryDatePicker/DateSelectSheet.tsx
@@ -10,7 +10,7 @@ import {
   YStack,
   styled,
 } from "tamagui";
-import { DateSelectModalProps } from "../../types";
+import { DateSelectSheetProps } from "../../types";
 
 const Overlay = styled(View, {
   position: "absolute",
@@ -24,12 +24,12 @@ const Overlay = styled(View, {
   exitStyle: { opacity: 0 },
 });
 
-export const DateSelectModal = ({
+export const DateSelectSheet = ({
   show,
   onClose,
   value,
   onChange,
-}: DateSelectModalProps) => {
+}: DateSelectSheetProps) => {
   const safeDate = React.useMemo(() => {
     const date = new Date(value);
     return isNaN(date.getTime()) ? new Date() : date;

--- a/src/features/food-add/components/ExpiryDatePicker/ExpiryDatePicker.tsx
+++ b/src/features/food-add/components/ExpiryDatePicker/ExpiryDatePicker.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import { Controller } from "react-hook-form";
 import { Button, Text, XStack, styled } from "tamagui";
 import { FoodFormProps } from "../../types";
-import { DateSelectModal } from "./DateSelectModal";
+import { DateSelectSheet } from "./DateSelectSheet";
 
 const LabelText = styled(Text, {
   fontFamily: "$heading",
@@ -53,7 +53,7 @@ export const ExpiryDatePicker = ({ control }: FoodFormProps) => {
             </Button>
           </XStack>
 
-          <DateSelectModal
+          <DateSelectSheet
             show={show}
             onClose={() => setShow(false)}
             value={

--- a/src/features/food-add/types/index.ts
+++ b/src/features/food-add/types/index.ts
@@ -32,7 +32,7 @@ interface CategoryAddFormValues {
   name: string;
 }
 
-interface CategoryAddModalProps {
+interface CategoryAddSheetProps {
   visible: boolean;
   onClose: () => void;
   onAdd: (name: string) => void | Promise<void>;
@@ -49,7 +49,7 @@ interface UnitSelectorProps {
   onChange: (value: string) => void;
 }
 
-interface DateSelectModalProps {
+interface DateSelectSheetProps {
   show: boolean;
   onClose: () => void;
   value: Date;
@@ -59,9 +59,9 @@ interface DateSelectModalProps {
 export {
   Category,
   CategoryAddFormValues,
-  CategoryAddModalProps,
+  CategoryAddSheetProps,
   CategorySelectorProps,
-  DateSelectModalProps,
+  DateSelectSheetProps,
   FoodFormProps,
   FoodFormValues,
   ImageUploaderProps,


### PR DESCRIPTION
## 작업 내용

- UI 정체성에 맞춰 BottomSheet의 역할을 하는 컴포넌트들의 이름을 ~Sheet로 변경하였습니다.

## 연관 이슈

- #63


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 음식 추가 기능의 카테고리 선택 및 만료일 선택 UI 컴포넌트의 내부 구조를 정렬했습니다. 사용자 경험에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->