### PR TITLE
Fix: 초기 구동 시 비로그인 상태의 토큰 재발급 요청 방지

### DIFF
--- a/src/shared/apis/apiClient.ts
+++ b/src/shared/apis/apiClient.ts
@@ -1,6 +1,13 @@
 import { tokenStorage } from "@/shared/lib/tokenStorage/tokenStorage";
 import axios from "axios";
 
+// 로그인 상태를 받아옴
+let getIsLoggedIn: (() => boolean) | null = null;
+
+export const setIsLoggedInGetter = (fn: () => boolean) => {
+  getIsLoggedIn = fn;
+};
+
 const apiClient = axios.create({
   baseURL: process.env.EXPO_PUBLIC_API_URL || "http://localhost:8080",
 });
@@ -34,6 +41,12 @@ apiClient.interceptors.response.use(
     }
 
     if (error.response.status === 401 && !originalConfig._retry) {
+      // 로그인되지 않은 상태면 재발급 시도 안함
+      const isLoggedIn = getIsLoggedIn?.() ?? false;
+      if (!isLoggedIn) {
+        return Promise.reject(error);
+      }
+
       originalConfig._retry = true;
       try {
         const refreshToken = await tokenStorage.getRefreshToken();

--- a/src/shared/providers/SessionProvider.tsx
+++ b/src/shared/providers/SessionProvider.tsx
@@ -3,6 +3,7 @@ import {
   useIsAuthLoaded,
   useIsLoggedIn,
 } from "@/features/auth/store/useAuthStore";
+import { setIsLoggedInGetter } from "@/shared/apis/apiClient";
 import { useRouter, useSegments } from "expo-router";
 import { useEffect } from "react";
 import { useFcmTokenSync } from "../hooks/useFcmTokenSync";
@@ -21,6 +22,11 @@ export function SessionProvider() {
 
   useFcmSync(isLoggedIn ? stableUserId : null, syncFcmToken);
   useNotificationHandler(isLoggedIn);
+
+  // 불필요한 토큰 재발급 방지를 위해apiClient에 로그인 상태 제공 -
+  useEffect(() => {
+    setIsLoggedInGetter(() => isLoggedIn);
+  }, [isLoggedIn]);
 
   useEffect(() => {
     if (!isLoaded) return;


### PR DESCRIPTION
## 작업 내용
- 비로그인 상태 앱 초기 진입 시 토큰 재발급 요청 차단
- apiClient.ts에 setIsLoggedInGetter 함수를 추가하여 외부에서 로그인 상태 확인 로직을 주입받을 수 있도록 개선
## 연관 이슈

- #70 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선사항
* **인증 상태 처리 개선**: 로그인 상태 변경이 API 요청 처리에 정확하게 반영됩니다. 로그아웃 상태에서 불필요한 재인증 시도를 방지하여 응답 속도를 개선하고, 로그인 중일 때는 인증 갱신이 정상적으로 작동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->