### PR TITLE
Fix: 앱 초기 진입시 홈 냉장고/식품 쿼리 enabled 조건에 로그인 상태 반영

### DIFF
--- a/src/features/fridge-management/hooks/queries/useFridgeListQuery.tsx
+++ b/src/features/fridge-management/hooks/queries/useFridgeListQuery.tsx
@@ -1,9 +1,14 @@
+import { useIsLoggedIn } from "@/features/auth/store/useAuthStore";
 import { useApiQuery } from "@/shared/apis/builder/ApiBuilder";
 import { QUERY_KEYS } from "@/shared/constants/queryKeys";
 import { getFridgeListApi } from "../../apis/fridge-management";
 
 const useFridgeListQuery = () => {
-  return useApiQuery(getFridgeListApi(), QUERY_KEYS.fridge.list());
+  const isLoggedIn = useIsLoggedIn();
+
+  return useApiQuery(getFridgeListApi(), QUERY_KEYS.fridge.list(), {
+    enabled: isLoggedIn,
+  });
 };
 
 export { useFridgeListQuery };

--- a/src/features/home/hooks/queries/useAllFoodStatusQuery.ts
+++ b/src/features/home/hooks/queries/useAllFoodStatusQuery.ts
@@ -1,3 +1,4 @@
+import { useIsLoggedIn } from "@/features/auth/store/useAuthStore";
 import { useApiQuery } from "@/shared/apis/builder/ApiBuilder";
 import { QUERY_KEYS } from "@/shared/constants/queryKeys";
 import { getFoodStatusApi } from "../../apis/food";
@@ -5,8 +6,10 @@ import { FoodStatusResponse } from "../../apis/food.types";
 import { normalizeFoodItem } from "../../utils/normalizeFoodItem";
 
 const useAllFoodStatusQuery = (enabled = true) => {
+  const isLoggedIn = useIsLoggedIn();
+
   return useApiQuery(getFoodStatusApi, QUERY_KEYS.food.statusAll(), {
-    enabled,
+    enabled: isLoggedIn && enabled,
     select: (response: FoodStatusResponse) => ({
       ...response,
       data: {

--- a/src/features/home/hooks/queries/useFridgeQuery.ts
+++ b/src/features/home/hooks/queries/useFridgeQuery.ts
@@ -1,9 +1,14 @@
+import { useIsLoggedIn } from "@/features/auth/store/useAuthStore";
 import { getFridgeApi } from "@/features/home/apis/fridge";
 import { useApiQuery } from "@/shared/apis/builder/ApiBuilder";
 import { QUERY_KEYS } from "@/shared/constants/queryKeys";
 
 const useFridgeQuery = () => {
-  return useApiQuery(getFridgeApi, QUERY_KEYS.fridge.list());
+  const isLoggedIn = useIsLoggedIn();
+
+  return useApiQuery(getFridgeApi, QUERY_KEYS.fridge.list(), {
+    enabled: isLoggedIn,
+  });
 };
 
 export { useFridgeQuery };


### PR DESCRIPTION
## 작업 내용

- 로그인 전 상태에서 홈의 식재료/냉장고 관련 쿼리가 실행되어 401이 발생하는 문제를 쿼리의 enabled 조건에 로그인 상태를 반영하여 방지
## 연관 이슈

- #73


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 여러 데이터 조회 기능이 사용자의 로그인 상태를 먼저 확인한 후에만 API 요청을 실행하도록 개선되었습니다.
* 인증되지 않은 사용자에 대한 불필요한 네트워크 요청이 방지되어 시스템 효율성과 성능이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->