### PR TITLE
Feat: 식재료 리스트에 식재료 이미지 추가

### DIFF
--- a/src/features/home/components/FoodListItem/FoodListItem.tsx
+++ b/src/features/home/components/FoodListItem/FoodListItem.tsx
@@ -4,7 +4,7 @@ import {
 } from "@/shared/constants/food";
 import { getExpiryLabel } from "@/shared/utils/date";
 import { getUnitLabel } from "@/shared/utils/food";
-import { Card, Heading, Text, View, XStack, YStack } from "tamagui";
+import { Card, Heading, Image, Text, View, XStack, YStack } from "tamagui";
 import { FoodListItemProps } from "../../types";
 
 export function FoodListItem({ item, onPress }: FoodListItemProps) {
@@ -27,7 +27,7 @@ export function FoodListItem({ item, onPress }: FoodListItemProps) {
       onPress={onPress}
       pressStyle={{ opacity: 0.85 }}
     >
-      <XStack p="$4" ai="center" space="$4">
+      <XStack p="$4" ai="center" gap="$4">
         <View
           position="absolute"
           left={0}
@@ -37,8 +37,17 @@ export function FoodListItem({ item, onPress }: FoodListItemProps) {
           backgroundColor={statusColor}
         />
 
-        <View p="$3" br="$3" bg="$gray2">
-          <View w={30} h={30} bg="$gray5" br="$2" />
+        <View ml="$2" w={54} h={54} br="$3" bg="$gray2" ov="hidden">
+          {item.imageURL ? (
+            <Image
+              source={{ uri: item.imageURL }}
+              w="100%"
+              h="100%"
+              objectFit="cover"
+            />
+          ) : (
+            <View w="100%" h="100%" bg="$gray5" />
+          )}
         </View>
 
         <YStack f={1} gap="$1">


### PR DESCRIPTION
## 작업 내용

- 식재료 리스트에 임의로 비워두었던 이미지 공간에 이미지 추가

## 연관 이슈

- #75


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 음식 목록 항목에 이미지 렌더링 기능을 추가했습니다. 음식 이미지가 있을 경우 표시되며, 이미지가 없을 때는 기본 플레이스홀더가 표시됩니다. 레이아웃 간격도 최적화되어 더 나은 시각적 구성을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->