### PR TITLE
Chore: 테마(다크, 라이트)에 따른 placeholder 색 지정

### DIFF
--- a/src/features/food-add/components/FoodNameInput.tsx
+++ b/src/features/food-add/components/FoodNameInput.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Control, Controller } from "react-hook-form";
-import { Input, Text, YStack, styled } from "tamagui";
+import { Input, Text, YStack, styled, useThemeName } from "tamagui";
 import { FoodFormValues } from "../types";
 
 const LabelText = styled(Text, {
@@ -14,36 +14,42 @@ export const FoodNameInput = ({
   control,
 }: {
   control: Control<FoodFormValues>;
-}) => (
-  <Controller
-    control={control}
-    name="name"
-    rules={{
-      required: "식품명을 입력해주세요.",
-      validate: (value) => value?.trim().length > 0 || "식품명을 입력해주세요.",
-      maxLength: { value: 20, message: "최대 20자까지 입력할 수 있습니다." },
-    }}
-    render={({ field: { onChange, value }, fieldState: { error } }) => (
-      <YStack>
-        <LabelText>식품명</LabelText>
-        {error && (
-          <Text color="$warning" fontSize="$3" fontWeight="600" mb="$2">
-            {error.message}
-          </Text>
-        )}
-        <Input
-          h={50}
-          value={value}
-          onChangeText={onChange}
-          placeholder="식품 이름을 입력하세요"
-          backgroundColor="$gray3"
-          fontSize="$3"
-          fontFamily="$baemin"
-          fontWeight="400"
-          br="$4"
-          bw={0}
-        />
-      </YStack>
-    )}
-  />
-);
+}) => {
+  const themeName = useThemeName();
+
+  return (
+    <Controller
+      control={control}
+      name="name"
+      rules={{
+        required: "식품명을 입력해주세요.",
+        validate: (value) =>
+          value?.trim().length > 0 || "식품명을 입력해주세요.",
+        maxLength: { value: 20, message: "최대 20자까지 입력할 수 있습니다." },
+      }}
+      render={({ field: { onChange, value }, fieldState: { error } }) => (
+        <YStack>
+          <LabelText>식품명</LabelText>
+          {error && (
+            <Text color="$warning" fontSize="$3" fontWeight="600" mb="$2">
+              {error.message}
+            </Text>
+          )}
+          <Input
+            h={50}
+            value={value}
+            onChangeText={onChange}
+            placeholder="식품 이름을 입력하세요"
+            placeholderTextColor={themeName === "dark" ? "$gray10" : "$gray5"}
+            backgroundColor="$gray3"
+            fontSize="$3"
+            fontFamily="$baemin"
+            fontWeight="400"
+            br="$4"
+            bw={0}
+          />
+        </YStack>
+      )}
+    />
+  );
+};

--- a/src/features/search/screens/SearchScreen.tsx
+++ b/src/features/search/screens/SearchScreen.tsx
@@ -40,6 +40,7 @@ export function SearchScreen() {
               borderWidth={0}
               backgroundColor="transparent"
               placeholder="식재료 이름을 검색해보세요"
+              placeholderTextColor={theme === "dark" ? "$gray10" : "$gray5"}
               value={searchQuery}
               onChangeText={setSearchQuery}
               focusStyle={{ borderWidth: 0 }}


### PR DESCRIPTION
## 작업 내용

- 가독성을 위해 검색 페이지, 음식 등록 페이지의 placeholder의 색을 지정

## 연관 이슈

- #79


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일
- 입력 필드의 플레이스홀더 텍스트 색상을 현재 테마 설정(밝음/어두움)에 따라 동적으로 조정하여 모든 환경에서 최적의 가시성을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->