### PR TITLE
Fix: 검색 페이지에서 식품 이미지 누락 수정

### DIFF
--- a/src/features/search/components/SearchResultItem.tsx
+++ b/src/features/search/components/SearchResultItem.tsx
@@ -36,11 +36,11 @@ export function SearchResultItem({ item, onPress }: Props) {
         bw={1}
         boc="$iconThumbnailBorder"
         ov="hidden"
+        p={1}
       >
         <View
           w="100%"
           h="100%"
-          m={1}
           br="$3"
           bg="$iconThumbnailInnerBackground"
           ov="hidden"

--- a/src/features/search/components/SearchResultItem.tsx
+++ b/src/features/search/components/SearchResultItem.tsx
@@ -1,7 +1,6 @@
 import { FoodItem } from "@/shared/types/food";
 import { Image, Text, View, XStack, YStack } from "tamagui";
 import { getDefaultFoodCategoryImage } from "../../../shared/utils/getDefaultFoodCategoryImage";
-
 interface Props {
   item: FoodItem;
   onPress?: () => void;
@@ -36,12 +35,11 @@ export function SearchResultItem({ item, onPress }: Props) {
         backgroundColor="$iconThumbnailBackground"
         bw={1}
         boc="$iconThumbnailBorder"
-        ai="center"
-        jc="center"
         ov="hidden"
       >
         <View
-          f={1}
+          w="100%"
+          h="100%"
           m={1}
           br="$3"
           bg="$iconThumbnailInnerBackground"


### PR DESCRIPTION
## 작업 내용

- View에서 f={1} (flex=1)로 인해 이미지가 제대로 렌더링 되지 않는 문제에 width와 height를 100%로 명시적 설정
- 필요 없는 스타일 제거
## 연관 이슈

- #83


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 검색 결과 항목의 썸네일 레이아웃을 조정했습니다.
  * 썸네일 내부의 크기 지정 방식을 변경해 이미지가 컨테이너를 더 정확히 채우도록 했습니다.
  * 썸네일 주변에 적당한 여백(패딩)을 추가해 시각적 정렬과 간격을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->