### PR TITLE
Fix: 로그인 리다이렉션 전 메인 페이지 노출 이슈 해결

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,5 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import { Stack, useSegments } from "expo-router";
+import { Stack } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { useCallback, useEffect, useState } from "react";
@@ -54,10 +54,6 @@ setBackgroundMessageHandler(messaging, async (remoteMessage) => {
   }
 });
 
-export const unstable_settings = {
-  anchor: "(tabs)",
-};
-
 SplashScreen.preventAutoHideAsync().catch(() => {});
 
 let hasShownAnimatedSplash = false;
@@ -66,7 +62,6 @@ export default function RootLayout() {
   useReactQueryDevTools(queryClient);
   const { isHydrated, resolvedTheme } = useAppHydration();
   const isLoggedIn = useIsLoggedIn();
-  const segments = useSegments();
   const [animationFinished, setAnimationFinished] = useState(
     hasShownAnimatedSplash,
   );
@@ -82,12 +77,7 @@ export default function RootLayout() {
     setAnimationFinished(true);
   }, []);
 
-  const currentGroup = segments?.[0];
-  const isRouteSettled =
-    isHydrated &&
-    typeof currentGroup === "string" &&
-    (isLoggedIn ? currentGroup !== "(auth)" : currentGroup === "(auth)");
-  const shouldShowSplash = !isAppReady || !animationFinished || !isRouteSettled;
+  const shouldShowSplash = !isAppReady || !animationFinished;
 
   useEffect(() => {
     SplashScreen.hideAsync().catch(() => {});
@@ -101,9 +91,15 @@ export default function RootLayout() {
             {/* 세션 관리 로직을 위해 스택 위에 배치 */}
             <SessionProvider />
 
-            <Stack screenOptions={{ headerShown: false }}>
-              <Stack.Screen name="(tabs)" />
-              <Stack.Screen name="(auth)" />
+            <Stack
+              key={isLoggedIn ? "logged-in" : "logged-out"}
+              screenOptions={{ headerShown: false }}
+            >
+              {isLoggedIn ? (
+                <Stack.Screen name="(tabs)" />
+              ) : (
+                <Stack.Screen name="(auth)" />
+              )}
               <Stack.Screen
                 name="modal"
                 options={{ presentation: "modal", title: "Modal" }}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,14 +1,15 @@
 import { QueryClientProvider } from "@tanstack/react-query";
-import { Stack } from "expo-router";
+import { Stack, useSegments } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { useCallback, useEffect, useState } from "react";
-import { View } from "react-native";
+import { StyleSheet, View } from "react-native";
 import "react-native-reanimated";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import Toast from "react-native-toast-message";
 import { TamaguiProvider } from "tamagui";
 
+import { useIsLoggedIn } from "@/features/auth/store/useAuthStore";
 import FridgeSplashScreen from "@/shared/components/FridgeSplashScreen";
 import { toastConfig } from "@/shared/components/ui/ToastConfig";
 import { useAppHydration } from "@/shared/hooks/useAppHydration";
@@ -64,6 +65,8 @@ let hasShownAnimatedSplash = false;
 export default function RootLayout() {
   useReactQueryDevTools(queryClient);
   const { isHydrated, resolvedTheme } = useAppHydration();
+  const isLoggedIn = useIsLoggedIn();
+  const segments = useSegments();
   const [animationFinished, setAnimationFinished] = useState(
     hasShownAnimatedSplash,
   );
@@ -79,19 +82,16 @@ export default function RootLayout() {
     setAnimationFinished(true);
   }, []);
 
+  const currentGroup = segments?.[0];
+  const isRouteSettled =
+    isHydrated &&
+    typeof currentGroup === "string" &&
+    (isLoggedIn ? currentGroup !== "(auth)" : currentGroup === "(auth)");
+  const shouldShowSplash = !isAppReady || !animationFinished || !isRouteSettled;
+
   useEffect(() => {
     SplashScreen.hideAsync().catch(() => {});
   }, []);
-
-  if (!isAppReady || !animationFinished) {
-    return (
-      <GestureHandlerRootView style={{ flex: 1 }}>
-        <View style={{ flex: 1 }}>
-          <FridgeSplashScreen onAnimationFinish={handleAnimationFinish} />
-        </View>
-      </GestureHandlerRootView>
-    );
-  }
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
@@ -109,6 +109,11 @@ export default function RootLayout() {
                 options={{ presentation: "modal", title: "Modal" }}
               />
             </Stack>
+            {shouldShowSplash && (
+              <View style={styles.splashOverlay}>
+                <FridgeSplashScreen onAnimationFinish={handleAnimationFinish} />
+              </View>
+            )}
             <StatusBar style="auto" />
             <Toast config={toastConfig} />
           </TamaguiProvider>
@@ -117,3 +122,10 @@ export default function RootLayout() {
     </GestureHandlerRootView>
   );
 }
+
+const styles = StyleSheet.create({
+  splashOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 9999,
+  },
+});


### PR DESCRIPTION
## 작업 내용

-  스플래시 스크린을 초기 렌더 분기 반환 방식에서 오버레이 방식으로 전환
- useSegment와 isLoggedIn을 이용해서 라우트 확정 전까지 스플래시 스크린 표시

## 연관 이슈

- #88


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 로그인 상태에 따라 화면 흐름을 자동 전환하도록 구성하여 즉각적으로 로그인/로그아웃 화면이 반영됩니다.
  * 로그인 상태 변경 시 화면을 강제로 재로딩(재마운트)하여 UI 상태 일관성을 개선합니다.

* **버그 수정**
  * 스플래시 화면 렌더링을 레이아웃 내 오버레이로 전환하여 전환 중 깜빡임을 줄였습니다.
  * 앱 준비 및 애니메이션 완료 기준으로 스플래시 표시 로직을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->