### PR TITLE
Fix: 식품 수정 후 메인 페이지 목록 갱신 누락 수정

### DIFF
--- a/src/features/food-edit/__tests__/hooks/useUpdateFoodMutation.test.tsx
+++ b/src/features/food-edit/__tests__/hooks/useUpdateFoodMutation.test.tsx
@@ -75,11 +75,11 @@ describe("useUpdateFoodMutation 테스트", () => {
       expect.objectContaining({ type: "success", text1: "식품 수정 완료" }),
     );
 
-    // 상태 목록 쿼리들은 refetchType: inactive로 처리
+    // 상태 목록 쿼리들은 active/inactive 상관없이 즉시 재조회
     expect(invalidateSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         queryKey: expect.arrayContaining(["foods", "status", "all"]),
-        refetchType: "inactive",
+        refetchType: "all",
       }),
     );
 

--- a/src/features/food-edit/__tests__/hooks/useUpdateFoodMutation.test.tsx
+++ b/src/features/food-edit/__tests__/hooks/useUpdateFoodMutation.test.tsx
@@ -83,6 +83,24 @@ describe("useUpdateFoodMutation 테스트", () => {
       }),
     );
 
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: expect.arrayContaining(["foods", "status", TEST_FRIDGE_ID]),
+        refetchType: "all",
+      }),
+    );
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: expect.arrayContaining([
+          "foods",
+          "statusByRefrigerator",
+          TEST_FRIDGE_ID,
+        ]),
+        refetchType: "all",
+      }),
+    );
+
     // 상세 쿼리는 즉시 재조회
     expect(invalidateSpy).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/features/food-edit/hooks/mutations/useUpdateFoodMutation.ts
+++ b/src/features/food-edit/hooks/mutations/useUpdateFoodMutation.ts
@@ -22,17 +22,17 @@ const useUpdateFoodMutation = (fridgeId: number, foodId: number) => {
 
         queryClient.invalidateQueries({
           queryKey: QUERY_KEYS.food.statusAll(),
-          refetchType: "inactive",
+          refetchType: "all",
         });
 
         queryClient.invalidateQueries({
           queryKey: QUERY_KEYS.food.status(fridgeId),
-          refetchType: "inactive",
+          refetchType: "all",
         });
 
         queryClient.invalidateQueries({
           queryKey: QUERY_KEYS.food.statusByRefrigerator(fridgeId),
-          refetchType: "inactive",
+          refetchType: "all",
         });
 
         queryClient.invalidateQueries({


### PR DESCRIPTION
## 작업 내용

- 식품 수정 성공 후 메인 식품 목록에서 쿼리 갱신 보장: 관련 foods 상태별 목록 쿼리 invalidate 시 refetchType을 inactive → all로 변경해, 화면에 떠 있는(active) 목록도 즉시 재조회되도록 수정
- 테스트 수정: useUpdateFoodMutation 테스트에서 refetchType: "all" 호출을 기대하도록 업데이트

## 연관 이슈

- #93


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 음식 상태 조회 데이터가 모든 상황에서 정확하게 업데이트되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->