### PR TITLE
Refactor: AuthInput 컴포넌트 유효성 로직 리팩토링 및 UX 개선

### DIFF
--- a/src/features/auth/components/AuthInput.tsx
+++ b/src/features/auth/components/AuthInput.tsx
@@ -8,11 +8,9 @@ export function AuthInput({
   label,
   name,
   control,
-  errors,
   rules,
   ...props
 }: AuthInputProps) {
-  const error = errors?.[name];
   const theme = useThemeStore((state) => state.theme);
   const systemColorScheme = useColorScheme();
   const isDark = resolveTheme(theme, systemColorScheme) === "dark";
@@ -26,33 +24,43 @@ export function AuthInput({
         control={control}
         name={name}
         rules={rules}
-        render={({ field: { onChange, onBlur, value } }) => (
-          <Input
-            h={56}
-            fontSize="$3"
-            bc="$surface"
-            bw={error ? 1.5 : 0}
-            boc="$warning"
-            br="$3"
-            px="$4"
-            color="$mainText"
-            placeholderTextColor={isDark ? "#4A5A56" : "#9CA3AF"}
-            onBlur={onBlur}
-            onChangeText={onChange}
-            value={value}
-            style={{
-              fontFamily: Platform.OS === "ios" ? "System" : "sans-serif",
-            }}
-            focusStyle={{ bc: "$surface", bw: 2, boc: "$primary" }}
-            {...props}
-          />
-        )}
+        render={({ field: { onChange, onBlur, value }, fieldState }) => {
+          const hasError = !!fieldState.error;
+
+          return (
+            <YStack>
+              <Input
+                h={56}
+                fontSize="$3"
+                bc="$surface"
+                bw={hasError ? 1.5 : 0}
+                boc="$warning"
+                br="$3"
+                px="$4"
+                color="$mainText"
+                placeholderTextColor={isDark ? "#4A5A56" : "#9CA3AF"}
+                onBlur={onBlur}
+                onChangeText={onChange}
+                value={value}
+                style={{
+                  fontFamily: Platform.OS === "ios" ? "System" : "sans-serif",
+                }}
+                focusStyle={{
+                  bc: "$surface",
+                  bw: 2,
+                  boc: hasError ? "$warning" : "$primary",
+                }}
+                {...props}
+              />
+              {hasError && (
+                <Text color="$warning" fontSize="$3" ml="$1" mt="$2">
+                  {fieldState.error?.message}
+                </Text>
+              )}
+            </YStack>
+          );
+        }}
       />
-      {error && (
-        <Text color="$warning" fontSize="$3" ml="$1">
-          {error.message?.toString()}
-        </Text>
-      )}
     </YStack>
   );
 }

--- a/src/features/auth/components/AuthInput.tsx
+++ b/src/features/auth/components/AuthInput.tsx
@@ -25,7 +25,8 @@ export function AuthInput({
         name={name}
         rules={rules}
         render={({ field: { onChange, onBlur, value }, fieldState }) => {
-          const hasError = !!fieldState.error;
+          const hasError =
+            !!fieldState.error && fieldState.error.message?.trim() !== "";
 
           return (
             <YStack>

--- a/src/features/auth/screens/LoginScreen.tsx
+++ b/src/features/auth/screens/LoginScreen.tsx
@@ -29,7 +29,7 @@ export function LoginScreen() {
   const {
     control,
     handleSubmit,
-    formState: { errors, isValid },
+    formState: { isValid },
   } = useForm<AuthFormData>({
     mode: "onChange",
     defaultValues: {
@@ -83,7 +83,6 @@ export function LoginScreen() {
               label="아이디"
               name="id"
               control={control}
-              errors={errors}
               placeholder="아이디를 입력하세요."
               keyboardType="default"
               rules={{
@@ -103,7 +102,6 @@ export function LoginScreen() {
               label="비밀번호"
               name="password"
               control={control}
-              errors={errors}
               placeholder="비밀번호를 입력하세요."
               secureTextEntry
               rules={{

--- a/src/features/auth/screens/SignupScreen.tsx
+++ b/src/features/auth/screens/SignupScreen.tsx
@@ -22,7 +22,7 @@ export function SignupScreen() {
     control,
     handleSubmit,
     watch,
-    formState: { errors, isValid },
+    formState: { isValid },
   } = useForm<AuthFormData>({
     mode: "onChange",
     defaultValues: {
@@ -76,7 +76,6 @@ export function SignupScreen() {
               label="닉네임"
               name="nickname"
               control={control}
-              errors={errors}
               placeholder="닉네임을 입력하세요."
               rules={{
                 required: "닉네임을 입력해주세요.",
@@ -99,7 +98,6 @@ export function SignupScreen() {
               label="아이디"
               name="id"
               control={control}
-              errors={errors}
               placeholder="아이디를 입력하세요."
               keyboardType="default"
               rules={{
@@ -119,7 +117,6 @@ export function SignupScreen() {
               label="비밀번호"
               name="password"
               control={control}
-              errors={errors}
               placeholder="비밀번호를 입력하세요."
               secureTextEntry
               rules={{
@@ -136,7 +133,6 @@ export function SignupScreen() {
               label="비밀번호 확인"
               name="confirmPassword"
               control={control}
-              errors={errors}
               placeholder="비밀번호를 다시 입력하세요."
               secureTextEntry
               rules={{

--- a/src/features/auth/screens/SignupScreen.tsx
+++ b/src/features/auth/screens/SignupScreen.tsx
@@ -137,8 +137,13 @@ export function SignupScreen() {
               secureTextEntry
               rules={{
                 required: "비밀번호를 다시 입력해주세요.",
-                validate: (value: string) =>
-                  value === password || "비밀번호가 일치하지 않습니다.",
+                validate: (value: string) => {
+                  // 만약 비밀번호 확인 값이 아직 6자 미만이라면 에러를 띄우지 않음
+                  if (value.length < 6) return true;
+
+                  // 6자 이상일 때만 일치 여부를 검사
+                  return value === password || "비밀번호가 일치하지 않습니다.";
+                },
               }}
             />
 

--- a/src/features/auth/screens/SignupScreen.tsx
+++ b/src/features/auth/screens/SignupScreen.tsx
@@ -138,11 +138,17 @@ export function SignupScreen() {
               rules={{
                 required: "비밀번호를 다시 입력해주세요.",
                 validate: (value: string) => {
-                  // 만약 비밀번호 확인 값이 아직 6자 미만이라면 에러를 띄우지 않음
-                  if (value.length < 6) return true;
+                  const isMatch = value === password;
+                  const isLongEnough = value.length >= 6;
 
-                  // 6자 이상일 때만 일치 여부를 검사
-                  return value === password || "비밀번호가 일치하지 않습니다.";
+                  // 일치 및 6글자 이상이면 통과
+                  if (isMatch && isLongEnough) return true;
+
+                  // 6자 미만일떄 (minLength)
+                  if (!isLongEnough) return " ";
+
+                  // 6자 이상인데 틀렸을 때
+                  return "비밀번호가 일치하지 않습니다.";
                 },
               }}
             />

--- a/src/features/auth/types/auth.types.ts
+++ b/src/features/auth/types/auth.types.ts
@@ -1,4 +1,4 @@
-import { Control, FieldErrors } from "react-hook-form";
+import { Control } from "react-hook-form";
 
 interface AuthFormData {
   id: string;
@@ -11,7 +11,6 @@ interface AuthInputProps {
   label: string;
   name: keyof AuthFormData; // AuthFormData의 키값만 허용
   control: Control<any>;
-  errors: FieldErrors;
   rules?: object;
   placeholder?: string;
   secureTextEntry?: boolean;


### PR DESCRIPTION
## 작업 내용

AuthInput UI 동기화 문제 해결
- errors 객체에 의존하던 방식에서 fieldState를 직접 참조하는 방식으로 변경하여, 유효성 검사 통과 시 테두리 색상이 즉각 변경되지 않던 버그를 해결
- 더 이상 사용하지 않는 errors props를 컴포넌트와 타입 정의(AuthInputProps)에서 모두 제거

회원가입 사용자 경험(UX) 개선
- 비밀번호 확인 필드 입력 시, 최소 글자 수(6자)를 채우기 전에는 "일치하지 않습니다" 메시지가 노출되지 않도록 validate 조건을 보완

## 연관 이슈

- #95 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 비밀번호 확인 입력 필드 검증을 개선하여 6자 이상일 때만 일치 여부를 확인하도록 수정했습니다.
  
* **개선사항**
  * 입력 컴포넌트의 오류 표시 방식이 내부 폼 상태에서 직접 파생되도록 변경되어 오류 표시와 포커스 스타일이 더 정확해졌습니다.
  * 로그인/회원가입 화면의 제출 버튼 비활성화 로직은 기존처럼 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->