### PR TITLE
Feat: 카테고리 수정, 삭제 기능 구현

### DIFF
--- a/src/features/food-add/__tests__/apis/category.test.ts
+++ b/src/features/food-add/__tests__/apis/category.test.ts
@@ -1,4 +1,9 @@
-import { addCategoryApi, getCategoryApi } from "../../apis/category";
+import {
+  addCategoryApi,
+  deleteCategoryApi,
+  getCategoryApi,
+  updateCategoryApi,
+} from "../../apis/category";
 
 describe("Category API 테스트", () => {
   it("getCategoryApi는 올바른 URL과 메소드로 설정되어야 한다", () => {
@@ -17,5 +22,25 @@ describe("Category API 테스트", () => {
       `/api/v1/refrigerators/${refrigeratorId}/categories`,
     );
     expect(api.method).toBe("POST");
+  });
+
+  it("updateCategoryApi는 올바른 URL과 메소드로 설정되어야 한다", () => {
+    const refrigeratorId = 1;
+    const categoryId = 123;
+    const api = updateCategoryApi(refrigeratorId, categoryId) as any;
+    expect(api.endpoint).toBe(
+      `/api/v1/refrigerators/${refrigeratorId}/categories/${categoryId}`,
+    );
+    expect(api.method).toBe("PATCH");
+  });
+
+  it("deleteCategoryApi는 올바른 URL과 메소드로 설정되어야 한다", () => {
+    const refrigeratorId = 1;
+    const categoryId = 123;
+    const api = deleteCategoryApi(refrigeratorId, categoryId) as any;
+    expect(api.endpoint).toBe(
+      `/api/v1/refrigerators/${refrigeratorId}/categories/${categoryId}`,
+    );
+    expect(api.method).toBe("DELETE");
   });
 });

--- a/src/features/food-add/__tests__/hooks/useDeleteCategoryMutation.test.tsx
+++ b/src/features/food-add/__tests__/hooks/useDeleteCategoryMutation.test.tsx
@@ -1,0 +1,118 @@
+import apiClient from "@/shared/apis/apiClient";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react-native";
+import React from "react";
+import Toast from "react-native-toast-message";
+import { useDeleteCategoryMutation } from "../../hooks/mutations/useDeleteCategoryMutation";
+
+jest.mock("@/shared/apis/apiClient");
+jest.mock("react-native-toast-message", () => ({ show: jest.fn() }));
+
+const mockedApiClient = apiClient as jest.MockedFunction<typeof apiClient>;
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false },
+    mutations: { retry: false },
+  },
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe("useDeleteCategoryMutation 테스트", () => {
+  const fridgeId = 2008;
+  const categoryId = 42;
+  const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient.clear();
+  });
+
+  afterAll(() => {
+    queryClient.clear();
+    queryClient.getQueryCache().clear();
+    queryClient.getMutationCache().clear();
+  });
+
+  it("카테고리 삭제 성공 시 쿼리를 무효화하고 성공 토스트를 표시해야 한다", async () => {
+    mockedApiClient.mockResolvedValueOnce({ data: {} });
+
+    const { result } = renderHook(() => useDeleteCategoryMutation(fridgeId), {
+      wrapper,
+    });
+
+    result.current.mutate({ categoryId });
+
+    await waitFor(() => {
+      expect(mockedApiClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: `/api/v1/refrigerators/${fridgeId}/categories/${categoryId}`,
+          method: "DELETE",
+        }),
+      );
+
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["categories", fridgeId],
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "success",
+          text1: "카테고리 삭제 완료",
+        }),
+      );
+    });
+  });
+
+  it("카테고리 삭제 실패 시 에러 메시지를 포함한 토스트를 표시해야 한다", async () => {
+    const serverErrorMessage = "삭제할 수 없는 카테고리입니다.";
+    mockedApiClient.mockRejectedValueOnce({
+      response: {
+        data: {
+          error: { message: serverErrorMessage },
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useDeleteCategoryMutation(fridgeId), {
+      wrapper,
+    });
+
+    result.current.mutate({ categoryId });
+
+    await waitFor(() => {
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "error",
+          text1: "삭제 실패",
+          text2: serverErrorMessage,
+        }),
+      );
+    });
+  });
+
+  it("에러 메시지가 없을 때 기본 에러 메시지를 표시해야 한다", async () => {
+    mockedApiClient.mockRejectedValueOnce({
+      response: { status: 500 },
+    });
+
+    const { result } = renderHook(() => useDeleteCategoryMutation(fridgeId), {
+      wrapper,
+    });
+
+    result.current.mutate({ categoryId });
+
+    await waitFor(() => {
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "error",
+          text1: "삭제 실패",
+          text2: "카테고리 삭제 중 오류가 발생했습니다.",
+        }),
+      );
+    });
+  });
+});

--- a/src/features/food-add/__tests__/hooks/useUpdateCategoryMutation.test.tsx
+++ b/src/features/food-add/__tests__/hooks/useUpdateCategoryMutation.test.tsx
@@ -1,0 +1,119 @@
+import apiClient from "@/shared/apis/apiClient";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react-native";
+import React from "react";
+import Toast from "react-native-toast-message";
+import { useUpdateCategoryMutation } from "../../hooks/mutations/useUpdateCategoryMutation";
+
+jest.mock("@/shared/apis/apiClient");
+jest.mock("react-native-toast-message", () => ({ show: jest.fn() }));
+
+const mockedApiClient = apiClient as jest.MockedFunction<typeof apiClient>;
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false },
+    mutations: { retry: false },
+  },
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+describe("useUpdateCategoryMutation 테스트", () => {
+  const fridgeId = 2008;
+  const categoryId = 42;
+  const invalidateSpy = jest.spyOn(queryClient, "invalidateQueries");
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient.clear();
+  });
+
+  afterAll(() => {
+    queryClient.clear();
+    queryClient.getQueryCache().clear();
+    queryClient.getMutationCache().clear();
+  });
+
+  it("카테고리 수정 성공 시 쿼리를 무효화하고 성공 토스트를 표시해야 한다", async () => {
+    mockedApiClient.mockResolvedValueOnce({ data: {} });
+
+    const { result } = renderHook(() => useUpdateCategoryMutation(fridgeId), {
+      wrapper,
+    });
+
+    result.current.mutate({ categoryId, newName: "변경된 이름" });
+
+    await waitFor(() => {
+      expect(mockedApiClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: `/api/v1/refrigerators/${fridgeId}/categories/${categoryId}`,
+          method: "PATCH",
+          data: { newName: "변경된 이름" },
+        }),
+      );
+
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ["categories", fridgeId],
+      });
+
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "success",
+          text1: "카테고리 수정 완료",
+        }),
+      );
+    });
+  });
+
+  it("카테고리 수정 실패 시 에러 메시지를 포함한 토스트를 표시해야 한다", async () => {
+    const serverErrorMessage = "유효하지 않은 카테고리 이름입니다.";
+    mockedApiClient.mockRejectedValueOnce({
+      response: {
+        data: {
+          error: { message: serverErrorMessage },
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useUpdateCategoryMutation(fridgeId), {
+      wrapper,
+    });
+
+    result.current.mutate({ categoryId, newName: "잘못된 이름" });
+
+    await waitFor(() => {
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "error",
+          text1: "수정 실패",
+          text2: serverErrorMessage,
+        }),
+      );
+    });
+  });
+
+  it("에러 메시지가 없을 때 기본 에러 메시지를 표시해야 한다", async () => {
+    mockedApiClient.mockRejectedValueOnce({
+      response: { status: 500 },
+    });
+
+    const { result } = renderHook(() => useUpdateCategoryMutation(fridgeId), {
+      wrapper,
+    });
+
+    result.current.mutate({ categoryId, newName: "테스트" });
+
+    await waitFor(() => {
+      expect(Toast.show).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "error",
+          text1: "수정 실패",
+          text2: "카테고리 수정 중 오류가 발생했습니다.",
+        }),
+      );
+    });
+  });
+});

--- a/src/features/food-add/apis/category.ts
+++ b/src/features/food-add/apis/category.ts
@@ -1,5 +1,9 @@
 import ApiBuilder from "@/shared/apis/builder/ApiBuilder";
-import { AddCategoryRequest, CategoryListResponse } from "./category.types";
+import {
+  AddCategoryRequest,
+  CategoryListResponse,
+  UpdateCategoryRequest,
+} from "./category.types";
 
 const getCategoryApi = (refrigeratorId: number) =>
   ApiBuilder.create<void, CategoryListResponse>(
@@ -11,4 +15,19 @@ const addCategoryApi = (refrigeratorId: number) =>
     `/api/v1/refrigerators/${refrigeratorId}/categories`,
   ).setMethod("POST");
 
-export { addCategoryApi, getCategoryApi };
+const updateCategoryApi = (refrigeratorId: number, categoryId: number) =>
+  ApiBuilder.create<UpdateCategoryRequest, void>(
+    `/api/v1/refrigerators/${refrigeratorId}/categories/${categoryId}`,
+  ).setMethod("PATCH");
+
+const deleteCategoryApi = (refrigeratorId: number, categoryId: number) =>
+  ApiBuilder.create<void, void>(
+    `/api/v1/refrigerators/${refrigeratorId}/categories/${categoryId}`,
+  ).setMethod("DELETE");
+
+export {
+  addCategoryApi,
+  deleteCategoryApi,
+  getCategoryApi,
+  updateCategoryApi,
+};

--- a/src/features/food-add/apis/category.types.ts
+++ b/src/features/food-add/apis/category.types.ts
@@ -9,4 +9,12 @@ interface AddCategoryRequest {
   name: string;
 }
 
-export type { AddCategoryRequest, CategoryListResponse };
+interface UpdateCategoryRequest {
+  newName: string;
+}
+
+export type {
+  AddCategoryRequest,
+  CategoryListResponse,
+  UpdateCategoryRequest,
+};

--- a/src/features/food-add/components/CategorySelector/CategoryActionSheet.tsx
+++ b/src/features/food-add/components/CategorySelector/CategoryActionSheet.tsx
@@ -1,0 +1,155 @@
+import React from "react";
+import { Modal, Pressable, StyleSheet } from "react-native";
+import { AnimatePresence, Button, Text, View, XStack, YStack } from "tamagui";
+import { CategoryActionSheetProps } from "../../types";
+
+export const CategoryActionSheet = ({
+  visible,
+  onClose,
+  target,
+  onEdit,
+  onDelete,
+}: CategoryActionSheetProps) => {
+  const isDefaultType = Boolean(target?.isDefaultType);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="none"
+      onRequestClose={onClose}
+      statusBarTranslucent
+    >
+      <YStack f={1} jc="flex-end">
+        <Pressable style={styles.backdrop} onPress={onClose} />
+
+        <AnimatePresence>
+          {visible && (
+            <YStack
+              key="category-action-sheet"
+              bg="$background"
+              p="$5"
+              pb="$5"
+              gap="$4"
+              br="$6"
+              borderBottomLeftRadius={0}
+              borderBottomRightRadius={0}
+              zIndex={100}
+              animation="quick"
+              enterStyle={{ y: 50, opacity: 0 }}
+              exitStyle={{ y: 50, opacity: 0 }}
+              y={0}
+              opacity={1}
+            >
+              <View
+                w={40}
+                h={5}
+                bg="$gray4"
+                br="$4"
+                alignSelf="center"
+                mb="$2"
+              />
+
+              <YStack gap="$2" ai="center">
+                <Text fontSize="$5" fontWeight="700" fontFamily="$baemin">
+                  {target?.name ?? "카테고리"}
+                </Text>
+                <Text
+                  fontSize="$3"
+                  color="$gray10"
+                  textAlign="center"
+                  fontFamily="$baemin"
+                >
+                  {isDefaultType
+                    ? "기본 카테고리는 수정하거나 삭제할 수 없습니다."
+                    : "원하는 작업을 선택해주세요."}
+                </Text>
+              </YStack>
+
+              {isDefaultType ? (
+                <XStack>
+                  <Button
+                    flex={1}
+                    backgroundColor="$gray3"
+                    h={52}
+                    br="$4"
+                    onPress={onClose}
+                    pressStyle={{ scale: 0.97 }}
+                  >
+                    <Text color="$mainText" fontWeight="700" fontSize="$4">
+                      확인
+                    </Text>
+                  </Button>
+                </XStack>
+              ) : (
+                <YStack gap="$2">
+                  <Button
+                    backgroundColor="$primary"
+                    h={52}
+                    br="$4"
+                    onPress={() => {
+                      if (!target) return;
+                      onEdit(target);
+                      onClose();
+                    }}
+                    pressStyle={{ scale: 0.97 }}
+                  >
+                    <Text
+                      color="$mainText"
+                      fontWeight="700"
+                      fontSize="$4"
+                      fontFamily="$baemin"
+                    >
+                      이름 수정
+                    </Text>
+                  </Button>
+
+                  <Button
+                    backgroundColor="$warning"
+                    h={52}
+                    br="$4"
+                    onPress={() => {
+                      if (!target) return;
+                      onDelete(target);
+                      onClose();
+                    }}
+                    pressStyle={{ scale: 0.97 }}
+                  >
+                    <Text color="$white" fontWeight="700" fontSize="$4">
+                      삭제
+                    </Text>
+                  </Button>
+
+                  <Button
+                    backgroundColor="$gray3"
+                    h={52}
+                    br="$4"
+                    onPress={onClose}
+                    pressStyle={{ scale: 0.97 }}
+                  >
+                    <Text
+                      color="$mainText"
+                      fontWeight="700"
+                      fontSize="$4"
+                      fontFamily="$baemin"
+                    >
+                      취소
+                    </Text>
+                  </Button>
+                </YStack>
+              )}
+            </YStack>
+          )}
+        </AnimatePresence>
+      </YStack>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(0,0,0,0.5)",
+  },
+});
+

--- a/src/features/food-add/components/CategorySelector/CategoryFormSheet.tsx
+++ b/src/features/food-add/components/CategorySelector/CategoryFormSheet.tsx
@@ -17,14 +17,17 @@ import {
   XStack,
   YStack,
 } from "tamagui";
-import { CategoryAddFormValues, CategoryAddSheetProps } from "../../types";
+import { CategoryFormSheetProps, CategoryFormValues } from "../../types";
 
-export const CategoryAddSheet = ({
+export const CategoryFormSheet = ({
   visible,
   onClose,
   onAdd,
+  editTarget = null,
+  onUpdate,
   isPending = false,
-}: CategoryAddSheetProps) => {
+}: CategoryFormSheetProps) => {
+  const isEditMode = Boolean(editTarget);
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
 
   const {
@@ -32,7 +35,7 @@ export const CategoryAddSheet = ({
     handleSubmit,
     reset,
     formState: { errors },
-  } = useForm<CategoryAddFormValues>({
+  } = useForm<CategoryFormValues>({
     mode: "onChange",
     defaultValues: { name: "" },
   });
@@ -41,8 +44,10 @@ export const CategoryAddSheet = ({
     if (!visible) {
       reset({ name: "" });
       setIsKeyboardVisible(false);
+    } else {
+      reset({ name: editTarget?.name ?? "" });
     }
-  }, [visible, reset]);
+  }, [visible, editTarget, reset]);
 
   useEffect(() => {
     const showSub = Keyboard.addListener("keyboardDidShow", () =>
@@ -58,16 +63,23 @@ export const CategoryAddSheet = ({
     };
   }, []);
 
-  const onSubmit = async ({ name }: CategoryAddFormValues) => {
+  const onSubmit = async ({ name }: CategoryFormValues) => {
     if (isPending) return;
 
     const trimmedName = name.trim();
     if (!trimmedName) return;
 
     try {
-      await onAdd(trimmedName);
+      if (isEditMode && editTarget && onUpdate) {
+        await onUpdate(editTarget.id, trimmedName);
+      } else {
+        await onAdd(trimmedName);
+      }
     } catch (error) {
-      console.error("카테고리 추가 실패:", error);
+      console.error(
+        isEditMode ? "카테고리 수정 실패:" : "카테고리 추가 실패:",
+        error,
+      );
     }
   };
 
@@ -102,7 +114,7 @@ export const CategoryAddSheet = ({
           <AnimatePresence>
             {visible && (
               <YStack
-                key="category-add-sheet"
+                key="category-form-sheet"
                 bg="$background"
                 p="$5"
                 pb="$5"
@@ -127,7 +139,7 @@ export const CategoryAddSheet = ({
                 />
 
                 <Text fontSize="$5" fontWeight="700" fontFamily="$baemin">
-                  카테고리 추가
+                  {isEditMode ? "카테고리 수정" : "카테고리 추가"}
                 </Text>
 
                 <YStack gap="$2">
@@ -141,9 +153,11 @@ export const CategoryAddSheet = ({
                     }}
                     render={({ field: { onChange, value } }) => (
                       <Input
-                        autoFocus
+                        autoFocus={!isEditMode}
                         h={52}
-                        placeholder="새 카테고리 이름"
+                        placeholder={
+                          isEditMode ? "카테고리 이름" : "새 카테고리 이름"
+                        }
                         value={value}
                         onChangeText={onChange}
                         backgroundColor="$gray3"
@@ -175,7 +189,7 @@ export const CategoryAddSheet = ({
                       fontSize="$4"
                       fontFamily="$baemin"
                     >
-                      추가하기
+                      {isEditMode ? "저장하기" : "추가하기"}
                     </Text>
                   </Button>
                 </XStack>

--- a/src/features/food-add/components/CategorySelector/CategorySelector.tsx
+++ b/src/features/food-add/components/CategorySelector/CategorySelector.tsx
@@ -1,10 +1,15 @@
+import { ConfirmModal } from "@/shared/components/Modal/ConfirmModal";
 import { Plus } from "@tamagui/lucide-icons";
 import React, { useEffect, useState } from "react";
-import { Controller } from "react-hook-form";
+import { useController } from "react-hook-form";
+import { Pressable } from "react-native";
 import { Button, ScrollView, Text, XStack, YStack, styled } from "tamagui";
 import { useAddCategoryMutation } from "../../hooks/mutations/useAddCategoryMutation";
-import { CategorySelectorProps } from "../../types";
-import { CategoryAddSheet } from "./CategoryAddSheet";
+import { useDeleteCategoryMutation } from "../../hooks/mutations/useDeleteCategoryMutation";
+import { useUpdateCategoryMutation } from "../../hooks/mutations/useUpdateCategoryMutation";
+import { Category, CategorySelectorProps } from "../../types";
+import { CategoryActionSheet } from "./CategoryActionSheet";
+import { CategoryFormSheet } from "./CategoryFormSheet";
 
 const LabelText = styled(Text, { fontSize: 18, fontWeight: "700", mb: "$2" });
 
@@ -14,72 +19,160 @@ export const CategorySelector = ({
   onModalOpenChange,
   fridgeId,
 }: CategorySelectorProps) => {
-  const [isAddModalOpen, setIsAddModalOpen] = useState(false);
-  const { mutate: addCategory, isPending } = useAddCategoryMutation(fridgeId);
+  const {
+    field: { value, onChange },
+  } = useController({ control, name: "categoryId" });
+
+  const [isCategorySheetOpen, setCategorySheetOpen] = useState(false);
+  const [isActionSheetOpen, setActionSheetOpen] = useState(false);
+  const [actionTarget, setActionTarget] = useState<Category | null>(null);
+  const [editTarget, setEditTarget] = useState<Category | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Category | null>(null);
+  const [isDeleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+
+  const { mutate: addCategory, isPending: isAddPending } =
+    useAddCategoryMutation(fridgeId);
+  const { mutate: updateCategory, isPending: isUpdatePending } =
+    useUpdateCategoryMutation(fridgeId);
+  const { mutate: deleteCategory } = useDeleteCategoryMutation(fridgeId);
+
+  const isSheetPending = isAddPending || isUpdatePending;
 
   useEffect(() => {
-    onModalOpenChange?.(isAddModalOpen);
-  }, [isAddModalOpen, onModalOpenChange]);
+    onModalOpenChange?.(isCategorySheetOpen);
+  }, [isCategorySheetOpen, onModalOpenChange]);
 
-  const closeModal = () => setIsAddModalOpen(false);
+  const closeSheet = () => {
+    setCategorySheetOpen(false);
+    setEditTarget(null);
+  };
 
   const handleAddCategory = (name: string) => {
     addCategory(
       { name },
       {
         onSuccess: () => {
-          closeModal();
+          closeSheet();
         },
       },
     );
   };
-  return (
-    <Controller
-      control={control}
-      name="categoryId"
-      render={({ field: { onChange, value } }) => (
-        <YStack py="$2">
-          <LabelText>카테고리</LabelText>
-          <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-            <XStack gap="$2" flexWrap="nowrap">
-              {categories.map((cat) => (
-                <Button
-                  key={cat.id}
-                  backgroundColor={value === cat.id ? "$primary" : "$gray3"}
-                  color="$mainText"
-                  onPress={() => onChange(cat.id)}
-                  br="$4"
-                  size="$4"
-                  fontFamily="$baemin"
-                  fontSize="$3"
-                  px="$4"
-                >
-                  {cat.name}
-                </Button>
-              ))}
 
+  const handleUpdateCategory = (categoryId: number, name: string) => {
+    updateCategory(
+      { categoryId, newName: name },
+      {
+        onSuccess: () => {
+          closeSheet();
+        },
+      },
+    );
+  };
+
+  const openAddSheet = () => {
+    setEditTarget(null);
+    setCategorySheetOpen(true);
+  };
+
+  const handleCategoryLongPress = (cat: Category) => {
+    setActionTarget(cat);
+    setActionSheetOpen(true);
+  };
+
+  const handleConfirmDelete = () => {
+    if (!deleteTarget) return;
+    const catId = deleteTarget.id;
+    deleteCategory(
+      { categoryId: catId },
+      {
+        onSuccess: () => {
+          if (value === catId) {
+            const next = categories.find((c) => c.id !== catId);
+            if (next) onChange(next.id);
+          }
+        },
+      },
+    );
+  };
+
+  return (
+    <YStack py="$2">
+      <LabelText>카테고리</LabelText>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <XStack gap="$2" flexWrap="nowrap">
+          {categories.map((cat) => (
+            <Pressable
+              key={cat.id}
+              onPress={() => onChange(cat.id)}
+              onLongPress={() => handleCategoryLongPress(cat)}
+              delayLongPress={450}
+            >
               <Button
-                icon={<Plus size="$1" color="$mainText" />}
-                size="$4"
-                bg="$gray3"
+                pointerEvents="none"
+                backgroundColor={value === cat.id ? "$primary" : "$gray3"}
+                color="$mainText"
                 br="$4"
+                size="$4"
+                fontFamily="$baemin"
+                fontSize="$3"
                 px="$4"
-                onPress={() => setIsAddModalOpen(true)}
               >
-                <Text fontFamily="$baemin" fontSize="$3" color="$mainText">
-                  추가
-                </Text>
+                {cat.name}
               </Button>
-            </XStack>
-          </ScrollView>
-          <CategoryAddSheet
-            visible={isAddModalOpen}
-            onClose={closeModal}
-            onAdd={handleAddCategory}
-            isPending={isPending}
-          />
-        </YStack>
-      )}
-    />
+            </Pressable>
+          ))}
+
+          <Button
+            icon={<Plus size="$1" color="$mainText" />}
+            size="$4"
+            bg="$gray3"
+            br="$4"
+            px="$4"
+            onPress={openAddSheet}
+          >
+            <Text fontFamily="$baemin" fontSize="$3" color="$mainText">
+              추가
+            </Text>
+          </Button>
+        </XStack>
+      </ScrollView>
+      <CategoryActionSheet
+        visible={isActionSheetOpen}
+        onClose={() => setActionSheetOpen(false)}
+        target={actionTarget}
+        onEdit={(target) => {
+          setEditTarget(target);
+          setCategorySheetOpen(true);
+        }}
+        onDelete={(target) => {
+          setDeleteTarget(target);
+          setDeleteConfirmOpen(true);
+        }}
+      />
+      <CategoryFormSheet
+        visible={isCategorySheetOpen}
+        onClose={closeSheet}
+        onAdd={handleAddCategory}
+        editTarget={editTarget}
+        onUpdate={handleUpdateCategory}
+        isPending={isSheetPending}
+      />
+      <ConfirmModal
+        open={isDeleteConfirmOpen}
+        onOpenChange={(open) => {
+          setDeleteConfirmOpen(open);
+          if (!open) setDeleteTarget(null);
+        }}
+        title="카테고리 삭제"
+        description={
+          deleteTarget
+            ? `${deleteTarget.name} 카테고리를 삭제할까요?  삭제 후에는 되돌릴 수 없습니다.`
+            : ""
+        }
+        confirmText="삭제하기"
+        onConfirm={handleConfirmDelete}
+        confirmColor="$warning"
+      />
+    </YStack>
   );
 };

--- a/src/features/food-add/components/CategorySelector/CategorySelector.tsx
+++ b/src/features/food-add/components/CategorySelector/CategorySelector.tsx
@@ -34,7 +34,8 @@ export const CategorySelector = ({
     useAddCategoryMutation(fridgeId);
   const { mutate: updateCategory, isPending: isUpdatePending } =
     useUpdateCategoryMutation(fridgeId);
-  const { mutate: deleteCategory } = useDeleteCategoryMutation(fridgeId);
+  const { mutate: deleteCategory, isPending: isDeletePending } =
+    useDeleteCategoryMutation(fridgeId);
 
   const isSheetPending = isAddPending || isUpdatePending;
 
@@ -80,16 +81,27 @@ export const CategorySelector = ({
   };
 
   const handleConfirmDelete = () => {
-    if (!deleteTarget) return;
+    if (!deleteTarget || isDeletePending) return;
     const catId = deleteTarget.id;
+
     deleteCategory(
       { categoryId: catId },
       {
         onSuccess: () => {
           if (value === catId) {
-            const next = categories.find((c) => c.id !== catId);
-            if (next) onChange(next.id);
+            const idx = categories.findIndex((c) => c.id === catId);
+            const nextCategory =
+              idx >= 0
+                ? (categories[idx + 1] ?? categories[idx - 1] ?? null)
+                : null;
+            onChange(nextCategory?.id ?? 0);
           }
+          setDeleteConfirmOpen(false);
+          setDeleteTarget(null);
+        },
+        onError: () => {
+          setDeleteConfirmOpen(false);
+          setDeleteTarget(null);
         },
       },
     );
@@ -172,6 +184,8 @@ export const CategorySelector = ({
         confirmText="삭제하기"
         onConfirm={handleConfirmDelete}
         confirmColor="$warning"
+        closeOnConfirm={false}
+        confirmDisabled={isDeletePending}
       />
     </YStack>
   );

--- a/src/features/food-add/hooks/mutations/useDeleteCategoryMutation.tsx
+++ b/src/features/food-add/hooks/mutations/useDeleteCategoryMutation.tsx
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import Toast from "react-native-toast-message";
+import { deleteCategoryApi } from "../../apis/category";
+
+interface DeleteCategoryVariables {
+  categoryId: number;
+}
+
+const useDeleteCategoryMutation = (fridgeId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, any, DeleteCategoryVariables>({
+    mutationFn: async ({ categoryId }) => {
+      await deleteCategoryApi(fridgeId, categoryId).execute();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["categories", fridgeId] });
+      Toast.show({
+        type: "success",
+        text1: "카테고리 삭제 완료",
+        text2: "카테고리가 삭제되었습니다.",
+      });
+    },
+    onError: (error: any) => {
+      const serverMessage = error.response?.data?.error?.message;
+      Toast.show({
+        type: "error",
+        text1: "삭제 실패",
+        text2: serverMessage || "카테고리 삭제 중 오류가 발생했습니다.",
+      });
+    },
+  });
+};
+
+export { useDeleteCategoryMutation };

--- a/src/features/food-add/hooks/mutations/useUpdateCategoryMutation.tsx
+++ b/src/features/food-add/hooks/mutations/useUpdateCategoryMutation.tsx
@@ -1,0 +1,38 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import Toast from "react-native-toast-message";
+import { updateCategoryApi } from "../../apis/category";
+
+interface UpdateCategoryVariables {
+  categoryId: number;
+  newName: string;
+}
+
+const useUpdateCategoryMutation = (fridgeId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, any, UpdateCategoryVariables>({
+    mutationFn: async ({ categoryId, newName }) => {
+      await updateCategoryApi(fridgeId, categoryId)
+        .setData({ newName })
+        .execute();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["categories", fridgeId] });
+      Toast.show({
+        type: "success",
+        text1: "카테고리 수정 완료",
+        text2: "카테고리 이름이 변경되었습니다.",
+      });
+    },
+    onError: (error: any) => {
+      const serverMessage = error.response?.data?.error?.message;
+      Toast.show({
+        type: "error",
+        text1: "수정 실패",
+        text2: serverMessage || "카테고리 수정 중 오류가 발생했습니다.",
+      });
+    },
+  });
+};
+
+export { useUpdateCategoryMutation };

--- a/src/features/food-add/types/index.ts
+++ b/src/features/food-add/types/index.ts
@@ -32,15 +32,25 @@ interface CategorySelectorProps extends FoodFormProps {
   fridgeId: number;
 }
 
-interface CategoryAddFormValues {
+interface CategoryFormValues {
   name: string;
 }
 
-interface CategoryAddSheetProps {
+interface CategoryFormSheetProps {
   visible: boolean;
   onClose: () => void;
   onAdd: (name: string) => void | Promise<void>;
+  editTarget?: Category | null;
+  onUpdate?: (categoryId: number, name: string) => void | Promise<void>;
   isPending?: boolean;
+}
+
+interface CategoryActionSheetProps {
+  visible: boolean;
+  onClose: () => void;
+  target: Category | null;
+  onEdit: (target: Category) => void;
+  onDelete: (target: Category) => void;
 }
 
 interface ImageUploaderProps {
@@ -62,8 +72,9 @@ interface DateSelectSheetProps {
 
 export {
   Category,
-  CategoryAddFormValues,
-  CategoryAddSheetProps,
+  CategoryActionSheetProps,
+  CategoryFormSheetProps,
+  CategoryFormValues,
   CategorySelectorProps,
   DateSelectSheetProps,
   FoodFormProps,

--- a/src/shared/components/Modal/ConfirmModal.tsx
+++ b/src/shared/components/Modal/ConfirmModal.tsx
@@ -11,6 +11,8 @@ export const ConfirmModal = ({
   confirmText,
   onConfirm,
   confirmColor = "$warning",
+  closeOnConfirm = true,
+  confirmDisabled = false,
 }: ConfirmModalProps) => {
   return (
     <Dialog modal open={open} onOpenChange={onOpenChange}>
@@ -74,9 +76,12 @@ export const ConfirmModal = ({
               <Button
                 size="$5"
                 backgroundColor={confirmColor}
+                disabled={confirmDisabled}
                 onPress={() => {
                   onConfirm();
-                  onOpenChange(false);
+                  if (closeOnConfirm) {
+                    onOpenChange(false);
+                  }
                 }}
                 pressStyle={{ opacity: 0.8, scale: 0.98 }}
                 br="$2"

--- a/src/shared/components/Modal/ConfirmModal.types.ts
+++ b/src/shared/components/Modal/ConfirmModal.types.ts
@@ -6,6 +6,9 @@ interface ConfirmModalProps {
   confirmText: string;
   onConfirm: () => void;
   confirmColor?: string;
+  // false면 확인 후에도 열린 상태 유지 — 비동기 작업 끝난 뒤  닫기
+  closeOnConfirm?: boolean;
+  confirmDisabled?: boolean;
 }
 
 export { ConfirmModalProps };


### PR DESCRIPTION
## 작업 내용

- 카테고리 수정 기능 구현
- 카테고리 삭제 기능 구현
- 카테고리 길게 누를 시 -> 액션시트로 수정, 삭제 진입 -> 폼시트로 입력 처리
- 기존 추가만 담당했던 CategoryAddSheet 에서 수정기능까지 포함하여 CategoryFormSheet으로 이름 변경

## 연관 이슈

- #99


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 카테고리 이름 수정 및 삭제 기능 추가
  * 카테고리 길게 누름으로 수정/삭제 옵션 표시(액션 시트)
  * 수정용/추가용 통합 폼(편집 모드 지원) 및 삭제 확인 모달 개선
  * 삭제/수정 성공 시 사용자 안내 토스트 표시

* **테스트**
  * 수정·삭제 동작과 오류/성공 토스트를 검증하는 단위 테스트 추가

* **기타**
  * 확인 모달에 확인 동작 유지/비활성 옵션 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->