### PR TITLE
Fix: 온보딩 완료 후 로그인 화면 이동 실패 수정

### DIFF
--- a/src/shared/providers/OnboardingProvider.test.tsx
+++ b/src/shared/providers/OnboardingProvider.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react-native";
+import { act, render, waitFor } from "@testing-library/react-native";
 import { useRouter, useSegments } from "expo-router";
 
 import { useIsLoggedIn } from "@/features/auth/store/useAuthStore";
@@ -74,5 +74,23 @@ describe("OnboardingGate 테스트", () => {
     await waitFor(() => {
       expect(mockReplace).toHaveBeenCalledWith("/onboarding");
     });
+  });
+
+  it("온보딩 완료 후 로그인 화면이면 스토리지 기준으로 완료로 인식해 온보딩으로 되돌리지 않는다", async () => {
+    (useIsLoggedIn as jest.Mock).mockReturnValue(false);
+    (useSegments as jest.Mock).mockReturnValue(["(auth)", "login"]);
+    (getOnboardingCompleted as jest.Mock).mockResolvedValue(true);
+
+    render(<OnboardingGate />);
+
+    await waitFor(() => {
+      expect(getOnboardingCompleted).toHaveBeenCalled();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockReplace).not.toHaveBeenCalled();
   });
 });

--- a/src/shared/providers/OnboardingProvider.test.tsx
+++ b/src/shared/providers/OnboardingProvider.test.tsx
@@ -79,7 +79,7 @@ describe("OnboardingGate 테스트", () => {
   it("온보딩 완료 후 로그인 화면이면 스토리지 기준으로 완료로 인식해 온보딩으로 되돌리지 않는다", async () => {
     (useIsLoggedIn as jest.Mock).mockReturnValue(false);
     (useSegments as jest.Mock).mockReturnValue(["(auth)", "login"]);
-    (getOnboardingCompleted as jest.Mock).mockResolvedValue(true);
+    (getOnboardingCompleted as jest.Mock).mockResolvedValueOnce(true);
 
     render(<OnboardingGate />);
 

--- a/src/shared/providers/OnboardingProvider.tsx
+++ b/src/shared/providers/OnboardingProvider.tsx
@@ -1,52 +1,45 @@
 import { useIsLoggedIn } from "@/features/auth/store/useAuthStore";
 import { getOnboardingCompleted } from "@/shared/lib/onboarding/onboardingStorage";
 import { useRouter, useSegments } from "expo-router";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 export function OnboardingGate() {
   const router = useRouter();
   const segments = useSegments();
   const isLoggedIn = useIsLoggedIn();
 
-  const [isReady, setIsReady] = useState(false);
-  const [isCompleted, setIsCompleted] = useState(false);
-
+  // 완료 여부는 스토리지 기준으로 매번 조회
   useEffect(() => {
-    let mounted = true;
-    getOnboardingCompleted()
-      .then((completed) => {
-        if (!mounted) return;
-        setIsCompleted(completed);
-        setIsReady(true);
-      })
-      .catch(() => {
-        if (!mounted) return;
-        setIsCompleted(false);
-        setIsReady(true);
-      });
+    let cancelled = false;
+
+    (async () => {
+      let completed = false;
+      try {
+        completed = await getOnboardingCompleted();
+      } catch {
+        completed = false;
+      }
+      if (cancelled) return;
+
+      const currentRootSegment = String(segments?.[0] ?? "");
+      const inOnboarding = currentRootSegment === "onboarding";
+
+      if (!completed && !inOnboarding) {
+        router.replace("/onboarding" as any);
+        return;
+      }
+
+      if (completed && inOnboarding) {
+        if (isLoggedIn) router.replace("/(tabs)");
+        else router.replace("/(auth)/login");
+        return;
+      }
+    })();
 
     return () => {
-      mounted = false;
+      cancelled = true;
     };
-  }, []);
-
-  useEffect(() => {
-    if (!isReady) return;
-
-    const currentRootSegment = String(segments?.[0] ?? "");
-    const inOnboarding = currentRootSegment === "onboarding";
-
-    if (!isCompleted && !inOnboarding) {
-      router.replace("/onboarding" as any);
-      return;
-    }
-
-    if (isCompleted && inOnboarding) {
-      if (isLoggedIn) router.replace("/(tabs)");
-      else router.replace("/(auth)/login");
-      return;
-    }
-  }, [isReady, isCompleted, isLoggedIn, router, segments]);
+  }, [isLoggedIn, router, segments]);
 
   return null;
 }


### PR DESCRIPTION
## 작업 내용

- OnboardingGate에서 segments/isLoggedIn 바뀔 때마다 getOnboardingCompleted() 다시 읽도록 변경
- 완료 + 로그인 화면일 때 온보딩으로 replace 하지 않는 회귀 테스트 추가

## 연관 이슈

- #101


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 온보딩 플로우의 라우팅 동작이 더욱 안정적으로 개선되었습니다.
  * 로그인 화면에서 온보딩이 이미 완료된 경우 불필요한 네비게이션이 더 이상 발생하지 않습니다.
  * 컴포넌트 언마운트 후 네비게이션이 발생하는 문제가 해결되었습니다.

* **Tests**
  * 온보딩 완료 상태에서 라우터 동작이 올바르게 유지되는지 검증하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->