### PR TITLE
Fix:  Android 하단 safe-area 보정

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -4,11 +4,13 @@ import { Tabs, usePathname } from "expo-router";
 import { Calendar, Home, Plus, Search, User } from "lucide-react-native";
 import { useState } from "react";
 import { TouchableOpacity } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Circle, useTheme, View } from "tamagui";
 
 export default function TabLayout() {
   const theme = useTheme();
   const pathname = usePathname();
+  const insets = useSafeAreaInsets();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const activeColor = theme.active.get();
@@ -37,8 +39,9 @@ export default function TabLayout() {
             backgroundColor: theme.background.get(),
             borderTopWidth: 1,
             borderTopColor: theme.borderColor.get(),
-            height: 65,
+            height: 65 + insets.bottom,
             paddingTop: 3,
+            paddingBottom: insets.bottom,
             elevation: 0, // 안드로이드 특유의 그림자 제거
             display: shouldHideFooter ? "none" : "flex",
           },
@@ -93,7 +96,7 @@ export default function TabLayout() {
         <View
           style={{
             position: "absolute",
-            bottom: 35,
+            bottom: insets.bottom + 35,
             alignSelf: "center",
             zIndex: 2000,
           }}

--- a/src/features/food-add/screens/FoodAddScreen.tsx
+++ b/src/features/food-add/screens/FoodAddScreen.tsx
@@ -10,6 +10,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { Keyboard } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Toast from "react-native-toast-message";
 import { Button, ScrollView, Text, XStack, YStack } from "tamagui";
 import { CategorySelector } from "../components/CategorySelector/CategorySelector";
@@ -25,6 +26,7 @@ import { FoodFormValues } from "../types";
 const EXTRA_SCROLL_HEIGHT = 180;
 
 export function FoodAddScreen() {
+  const insets = useSafeAreaInsets();
   const selectedFridgeId = useSelectedFridgeId();
   const isAllFridgeTab = useIsAllFridgeTab();
   const { setSelectedFridgeId } = useFridgeActions();
@@ -148,7 +150,10 @@ export function FoodAddScreen() {
           keyboardScrollRef.current = ref;
         }}
         style={{ flex: 1 }}
-        contentContainerStyle={{ flexGrow: 1, paddingBottom: 20 }}
+        contentContainerStyle={{
+          flexGrow: 1,
+          paddingBottom: insets.bottom + 65 + 24,
+        }}
         keyboardShouldPersistTaps="handled"
         enableOnAndroid
         extraScrollHeight={EXTRA_SCROLL_HEIGHT}
@@ -204,7 +209,11 @@ export function FoodAddScreen() {
       </KeyboardAwareScrollView>
 
       {!isCategoryModalOpen && !isKeyboardVisible && (
-        <YStack p="$4" pb="$6" backgroundColor="$background">
+        <YStack
+          p="$4"
+          backgroundColor="$background"
+          style={{ paddingBottom: insets.bottom + 24 }}
+        >
           <Button
             backgroundColor="$primary"
             size="$6"

--- a/src/features/food-add/screens/FoodAddScreen.tsx
+++ b/src/features/food-add/screens/FoodAddScreen.tsx
@@ -152,7 +152,7 @@ export function FoodAddScreen() {
         style={{ flex: 1 }}
         contentContainerStyle={{
           flexGrow: 1,
-          paddingBottom: insets.bottom + 65 + 24,
+          paddingBottom: insets.bottom + 24,
         }}
         keyboardShouldPersistTaps="handled"
         enableOnAndroid

--- a/src/features/food-detail/screens/FoodDetailScreen.tsx
+++ b/src/features/food-detail/screens/FoodDetailScreen.tsx
@@ -1,6 +1,7 @@
 import { Header } from "@/shared/components/Header/Header";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { Button, ScrollView, Spinner, Text, YStack } from "tamagui";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { FoodDetailCard } from "../components/FoodDetail/FoodDetailCard";
 import { FoodStatusView } from "../components/FoodStatusView";
 import { ImageSection } from "../components/ImageSection";
@@ -9,6 +10,7 @@ import { parseParamToNumber } from "../utils/params";
 
 export function FoodDetailScreen() {
   const router = useRouter();
+  const insets = useSafeAreaInsets();
   const { id, refrigeratorId } = useLocalSearchParams<{
     id?: string;
     refrigeratorId?: string;
@@ -68,12 +70,14 @@ export function FoodDetailScreen() {
     );
   }
 
+  const bottomPadding = insets.bottom + 65 + 24;
+
   return (
     <YStack f={1} backgroundColor="$background">
       <Header title="식품 상세" showBackButton />
 
       <ScrollView f={1} showsVerticalScrollIndicator={false}>
-        <YStack px="$4" py="$5" gap="$4" pb="$10">
+        <YStack px="$4" py="$5" gap="$4" style={{ paddingBottom: bottomPadding }}>
           <ImageSection imageURL={food.imageURL} />
           <FoodDetailCard food={food} />
           <Button

--- a/src/features/food-detail/screens/FoodDetailScreen.tsx
+++ b/src/features/food-detail/screens/FoodDetailScreen.tsx
@@ -1,7 +1,7 @@
 import { Header } from "@/shared/components/Header/Header";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { Button, ScrollView, Spinner, Text, YStack } from "tamagui";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Button, ScrollView, Spinner, Text, YStack } from "tamagui";
 import { FoodDetailCard } from "../components/FoodDetail/FoodDetailCard";
 import { FoodStatusView } from "../components/FoodStatusView";
 import { ImageSection } from "../components/ImageSection";
@@ -70,14 +70,19 @@ export function FoodDetailScreen() {
     );
   }
 
-  const bottomPadding = insets.bottom + 65 + 24;
+  const bottomPadding = insets.bottom + 24;
 
   return (
     <YStack f={1} backgroundColor="$background">
       <Header title="식품 상세" showBackButton />
 
       <ScrollView f={1} showsVerticalScrollIndicator={false}>
-        <YStack px="$4" py="$5" gap="$4" style={{ paddingBottom: bottomPadding }}>
+        <YStack
+          px="$4"
+          py="$5"
+          gap="$4"
+          style={{ paddingBottom: bottomPadding }}
+        >
           <ImageSection imageURL={food.imageURL} />
           <FoodDetailCard food={food} />
           <Button

--- a/src/features/food-edit/screens/FoodEditScreen.tsx
+++ b/src/features/food-edit/screens/FoodEditScreen.tsx
@@ -11,6 +11,7 @@ import { Header } from "@/shared/components/Header/Header";
 import { useLocalSearchParams } from "expo-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Toast from "react-native-toast-message";
 import {
   Button,
@@ -31,6 +32,7 @@ const LabelText = styled(Text, {
 });
 
 export function FoodEditScreen() {
+  const insets = useSafeAreaInsets();
   const { id, refrigeratorId } = useLocalSearchParams<{
     id?: string;
     refrigeratorId?: string;
@@ -235,7 +237,11 @@ export function FoodEditScreen() {
       </ScrollView>
 
       {!isCategoryModalOpen && (
-        <YStack p="$4" pb="$6" backgroundColor="$background">
+        <YStack
+          p="$4"
+          backgroundColor="$background"
+          style={{ paddingBottom: insets.bottom + 24 }}
+        >
           <Button
             backgroundColor="$primary"
             size="$6"

--- a/src/features/onboarding/hooks/useOnboarding.test.tsx
+++ b/src/features/onboarding/hooks/useOnboarding.test.tsx
@@ -41,8 +41,8 @@ describe("useOnboarding 테스트", () => {
 
     act(() => {
       result.current.onScrollEnd({
-        nativeEvent: { contentOffset: { x } },
-      });
+        nativeEvent: { contentOffset: { x, y: 0 } },
+      } as any);
     });
 
     await waitFor(() => {

--- a/src/features/profile/screens/ProfileScreen.tsx
+++ b/src/features/profile/screens/ProfileScreen.tsx
@@ -11,6 +11,7 @@ import * as ImagePicker from "expo-image-picker";
 import { useRouter } from "expo-router";
 import React, { useEffect } from "react";
 import { Alert, Linking } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   Avatar,
   Button,
@@ -34,6 +35,7 @@ import {
 } from "../utils/getRandomDefaultProfileImage";
 
 export function ProfileScreen() {
+  const insets = useSafeAreaInsets();
   const { mutate: logout } = useLogoutMutation();
   const router = useRouter();
   const theme = useThemeStore((state) => state.theme);
@@ -147,7 +149,7 @@ export function ProfileScreen() {
       <Header title="마이페이지" showBackButton />
 
       <ScrollView showsVerticalScrollIndicator={false}>
-        <YStack padding="$4" gap="$6" paddingBottom="$8">
+        <YStack padding="$4" gap="$6" style={{ paddingBottom: insets.bottom + 24 }}>
           {/* 프로필 */}
           <YStack alignItems="center" gap="$2" marginTop="$4">
             <Avatar circular size={100}>

--- a/src/features/search/screens/SearchScreen.tsx
+++ b/src/features/search/screens/SearchScreen.tsx
@@ -5,28 +5,35 @@ import { Search as SearchIcon, X } from "@tamagui/lucide-icons";
 import { useRouter } from "expo-router";
 import { useState } from "react";
 import { useColorScheme } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
-import { Button, Input, Text, View, XStack, YStack } from "tamagui";
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from "react-native-safe-area-context";
+import { Button, Input, Text, View, XStack, YStack, useTheme } from "tamagui";
 import { SearchResultItem } from "../components/SearchResultItem";
 import { useSearchFood } from "../hooks/useSearchFood";
 
 export function SearchScreen() {
   const router = useRouter();
+  const insets = useSafeAreaInsets();
   const selectedFridgeId = useSelectedFridgeId();
+  const themeTokens = useTheme();
   const theme = useThemeStore((state) => state.theme);
   const systemColorScheme = useColorScheme();
   const isDark = resolveTheme(theme, systemColorScheme) === "dark";
   const [searchQuery, setSearchQuery] = useState("");
   const { filteredResult } = useSearchFood(searchQuery);
+  const backgroundColor = themeTokens.background.get();
 
   return (
     <SafeAreaView
+      edges={["top"]}
       style={{
         flex: 1,
-        backgroundColor: isDark ? "#0B1110" : "#F6F8F7",
+        backgroundColor,
       }}
     >
-      <YStack f={1} backgroundColor="$background">
+      <YStack f={1} backgroundColor={backgroundColor}>
         <XStack px="$3" py="$2" ai="center" gap="$2">
           <XStack
             f={1}
@@ -98,8 +105,9 @@ export function SearchScreen() {
               <View backgroundColor="$gray3" mx="$4" height={1} />
             )}
             contentContainerStyle={{
-              paddingBottom: 100,
+              paddingBottom: insets.bottom + 65 + 60,
             }}
+            style={{ backgroundColor }}
             ListEmptyComponent={
               searchQuery ? (
                 <YStack f={1} ai="center" jc="center" mt="$10">

--- a/src/shared/components/OverlayMenu/OverlayMenu.tsx
+++ b/src/shared/components/OverlayMenu/OverlayMenu.tsx
@@ -13,6 +13,7 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { View } from "tamagui";
 import { MenuIcon } from "./MenuIcon";
 
@@ -24,6 +25,7 @@ export function OverlayMenu({
   onClose: () => void;
 }) {
   const router = useRouter();
+  const insets = useSafeAreaInsets();
   // 0 애니메이션 시작 전, 1 애니메이션 완료
   const progress = useSharedValue(0);
 
@@ -95,7 +97,13 @@ export function OverlayMenu({
       </TouchableWithoutFeedback>
 
       <View f={1} jc="flex-end" ai="center" pointerEvents="box-none">
-        <Animated.View style={[menuGroupStyle, styles.menuContainer]}>
+        <Animated.View
+          style={[
+            menuGroupStyle,
+            styles.menuContainer,
+            { marginBottom: insets.bottom + 35 },
+          ]}
+        >
           {MENU_ITEMS.map((item, index) => (
             <MenuIcon
               key={index}


### PR DESCRIPTION
## 작업 내용

- 탭바 높이/패딩에 safe-area 하단 inset 반영하여 시스템 푸터 겹침 방지
-  플로팅 버튼과 오버레이 메뉴가 safe-area만큼 함께 올라오도록 위치 보정
- 검색/마이/식품 상세·추가·수정 화면 하단 패딩 보정으로 마지막 콘텐츠/버튼 가림 해결
- 온보딩 스크롤 이벤트 테스트의 타입 오류 보정

## 연관 이슈

- #103


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 하단 노치나 홈 인디케이터가 있는 기기에서 레이아웃 표시 개선
  * 탭 바 및 액션 버튼 위치 조정으로 안전 영역 더 잘 처리
  * 검색 화면 테마 일관성 개선

* **테스트**
  * 온보딩 훅 테스트 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->