### PR TITLE
Refactor: 전체 화면 반응형 레이아웃 적용

### DIFF
--- a/src/features/auth/components/AuthInput.tsx
+++ b/src/features/auth/components/AuthInput.tsx
@@ -3,6 +3,7 @@ import { Controller } from "react-hook-form";
 import { Platform, useColorScheme } from "react-native";
 import { Heading, Input, Text, YStack } from "tamagui";
 import { AuthInputProps } from "../types/auth.types";
+import { fs, ms, rv } from "@/shared/constants/layout";
 
 export function AuthInput({
   label,
@@ -17,7 +18,12 @@ export function AuthInput({
 
   return (
     <YStack gap="$2">
-      <Heading color="$mainText" fontWeight="700" fontSize="$2" ml="$1">
+      <Heading
+        color="$mainText"
+        fontWeight="700"
+        fontSize={rv({ sm: fs(12), md: fs(13), lg: fs(13) })}
+        ml="$1"
+      >
         {label}
       </Heading>
       <Controller
@@ -31,8 +37,8 @@ export function AuthInput({
           return (
             <YStack>
               <Input
-                h={56}
-                fontSize="$3"
+                h={rv({ sm: ms(44), md: ms(52), lg: ms(52) })}
+                fontSize={rv({ sm: fs(13), md: fs(14), lg: fs(14) })}
                 bc="$surface"
                 bw={hasError ? 1.5 : 0}
                 boc="$warning"
@@ -54,7 +60,12 @@ export function AuthInput({
                 {...props}
               />
               {hasError && (
-                <Text color="$warning" fontSize="$3" ml="$1" mt="$2">
+                <Text
+                  color="$warning"
+                  fontSize={rv({ sm: fs(12), md: fs(13), lg: fs(13) })}
+                  ml="$1"
+                  mt="$2"
+                >
                   {fieldState.error?.message}
                 </Text>
               )}

--- a/src/features/auth/screens/LoginScreen.tsx
+++ b/src/features/auth/screens/LoginScreen.tsx
@@ -13,6 +13,7 @@ import {
   YStack,
 } from "tamagui";
 
+import { fs, ms, rv } from "@/shared/constants/layout";
 import { resolveTheme, useThemeStore } from "@/shared/stores/useThemeStore";
 import { useForm } from "react-hook-form";
 import { AuthInput } from "../components/AuthInput";
@@ -58,11 +59,22 @@ export function LoginScreen() {
         resetScrollToCoords={{ x: 0, y: 0 }}
         scrollEnabled={true}
         enableOnAndroid={true}
-        extraScrollHeight={20}
+        extraScrollHeight={rv({ sm: ms(12), md: ms(20), lg: ms(20) })}
       >
-        <YStack f={1} px="$6" jc="center" bc="$gray1">
-          <YStack mb={40}>
-            <Heading fontWeight="700" color="$primary" fontSize={30} lh="$6">
+        <YStack
+          f={1}
+          px={rv({ sm: "$5", md: "$6", lg: "$6" })}
+          jc="center"
+          bc="$gray1"
+        >
+          <YStack mb={rv({ sm: ms(24), md: ms(40), lg: ms(40) })}>
+            <Heading
+              fontWeight="700"
+              color="$primary"
+              fontFamily="$baemin"
+              fontSize={rv({ sm: fs(24), md: fs(30), lg: fs(30) })}
+              lh={rv({ sm: ms(30), md: ms(34), lg: ms(40) })}
+            >
               Fridgely
             </Heading>
             <Spacer size="$2" />
@@ -70,8 +82,8 @@ export function LoginScreen() {
               fontFamily="$baemin"
               fontWeight="400"
               color="$gray10"
-              fontSize="$3"
-              lh={24}
+              fontSize={rv({ sm: fs(13), md: fs(14), lg: fs(14) })}
+              lh={rv({ sm: ms(20), md: ms(24), lg: ms(24) })}
             >
               스마트한 냉장고 관리의 시작.{"\n"}
               버려지는 식재료 없이 신선하게 유지하세요.
@@ -119,10 +131,10 @@ export function LoginScreen() {
             <Button
               bc="$primary"
               color="$white"
-              h={56}
+              h={rv({ sm: ms(48), md: ms(56), lg: ms(56) })}
               br="$3"
               fontWeight="700"
-              fontSize="$4"
+              fontSize={rv({ sm: fs(14), md: fs(16), lg: fs(16) })}
               icon={LogIn}
               pressStyle={{ opacity: 0.8, scale: 0.98 }}
               onPress={handleSubmit(handleLoginClick)}
@@ -136,7 +148,7 @@ export function LoginScreen() {
             <XStack gap="$2" ai="center">
               <Text
                 fontFamily="$baemin"
-                fontWeight="400"
+                fontWeight="700"
                 color="$gray10"
                 fontSize="$3"
               >

--- a/src/features/auth/screens/LoginScreen.tsx
+++ b/src/features/auth/screens/LoginScreen.tsx
@@ -72,8 +72,8 @@ export function LoginScreen() {
               fontWeight="700"
               color="$primary"
               fontFamily="$baemin"
-              fontSize={rv({ sm: fs(24), md: fs(30), lg: fs(30) })}
-              lh={rv({ sm: ms(30), md: ms(34), lg: ms(40) })}
+              fontSize={rv({ sm: fs(24), md: fs(28), lg: fs(30) })}
+              lh={rv({ sm: ms(30), md: ms(35), lg: ms(40) })}
             >
               Fridgely
             </Heading>
@@ -145,7 +145,7 @@ export function LoginScreen() {
           </YStack>
 
           <YStack mt="$2" ai="center" gap="$3">
-            <XStack gap="$2" ai="center">
+            <XStack ai="center">
               <Text
                 fontFamily="$baemin"
                 fontWeight="700"

--- a/src/features/auth/screens/SignupScreen.tsx
+++ b/src/features/auth/screens/SignupScreen.tsx
@@ -10,6 +10,7 @@ import { Button, H2, Spacer, Text, XStack, YStack } from "tamagui";
 import { AuthInput } from "../components/AuthInput";
 import { useSignupMutation } from "../hooks/useAuthMutation";
 import { AuthFormData } from "../types/auth.types";
+import { fs, ms, rv } from "@/shared/constants/layout";
 
 export function SignupScreen() {
   const router = useRouter();
@@ -55,10 +56,16 @@ export function SignupScreen() {
         style={{ flex: 1 }}
         contentContainerStyle={{ flexGrow: 1 }}
         enableOnAndroid={true}
-        extraScrollHeight={30}
+        extraScrollHeight={rv({ sm: ms(16), md: ms(30), lg: ms(30) })}
         keyboardShouldPersistTaps="handled"
       >
-        <YStack f={1} px="$6" jc="center" bc="$gray1" py="$10">
+        <YStack
+          f={1}
+          px={rv({ sm: "$5", md: "$6", lg: "$6" })}
+          jc="center"
+          bc="$gray1"
+          py={rv({ sm: "$8", md: "$10", lg: "$10" })}
+        >
           <YStack mb="$6">
             <XStack ai="center" ml="$-2" mb="$4" onPress={() => router.back()}>
               <ArrowLeft size="$1" color="$gray10" />
@@ -66,7 +73,12 @@ export function SignupScreen() {
                 로그인으로 돌아가기
               </Text>
             </XStack>
-            <H2 fontWeight="900" color="$primary" fontSize={32} ls={-1}>
+            <H2
+              fontWeight="900"
+              color="$primary"
+              fontSize={rv({ sm: fs(24), md: fs(32), lg: fs(32) })}
+              ls={-1}
+            >
               회원가입
             </H2>
           </YStack>
@@ -158,10 +170,10 @@ export function SignupScreen() {
             <Button
               bc="$primary"
               color="$white"
-              h={56}
+              h={rv({ sm: ms(48), md: ms(56), lg: ms(56) })}
               br="$3"
               fontWeight="700"
-              fontSize="$4"
+              fontSize={rv({ sm: fs(14), md: fs(16), lg: fs(16) })}
               pressStyle={{ opacity: 0.8, scale: 0.98 }}
               onPress={handleSubmit(onSignUpClick)}
               disabled={!isValid || isSignupPending}

--- a/src/features/calendar/components/CalendarFoodList.tsx
+++ b/src/features/calendar/components/CalendarFoodList.tsx
@@ -8,6 +8,7 @@ import {
   getSelectedDateLabel,
   getStorageLabel,
 } from "../utils/calendar";
+import { fs, ms, rv, s } from "@/shared/constants/layout";
 
 export function CalendarFoodList({
   selectedDate,
@@ -19,12 +20,16 @@ export function CalendarFoodList({
   return (
     <YStack f={1} mt="$2" backgroundColor="$gray1">
       <View
-        p="$4"
+        p={rv({ sm: "$3", md: "$4", lg: "$4" })}
         backgroundColor="$background"
-        borderTopWidth={10}
+        borderTopWidth={s(10)}
         borderTopColor="$gray3"
       >
-        <Text fontSize={18} fontWeight="700" fontFamily="$baemin">
+        <Text
+          fontSize={rv({ sm: fs(14), md: fs(16), lg: fs(16) })}
+          fontWeight="700"
+          fontFamily="$baemin"
+        >
           {selectedDateLabel}
         </Text>
       </View>
@@ -40,8 +45,8 @@ export function CalendarFoodList({
                 key={food.id}
                 ai="center"
                 jc="space-between"
-                px="$4"
-                py="$4"
+                px={rv({ sm: "$3", md: "$4", lg: "$4" })}
+                py={rv({ sm: "$3", md: "$4", lg: "$4" })}
                 bc="$gray4"
                 backgroundColor="$background"
                 onPress={() => onPress?.(food)}
@@ -49,8 +54,8 @@ export function CalendarFoodList({
               >
                 <XStack ai="center" gap="$3" f={1}>
                   <View
-                    w={56}
-                    h={56}
+                    w={rv({ sm: ms(44), md: ms(50), lg: ms(50) })}
+                    h={rv({ sm: ms(44), md: ms(50), lg: ms(50) })}
                     br="$4"
                     backgroundColor="$iconThumbnailBackground"
                     bw={1}
@@ -60,8 +65,8 @@ export function CalendarFoodList({
                     ov="hidden"
                   >
                     <View
-                      w={54}
-                      h={54}
+                      w={rv({ sm: ms(42), md: ms(48), lg: ms(48) })}
+                      h={rv({ sm: ms(42), md: ms(48), lg: ms(48) })}
                       br="$4"
                       bg="$iconThumbnailInnerBackground"
                       ov="hidden"
@@ -72,7 +77,10 @@ export function CalendarFoodList({
                             ? { uri: food.imageURL }
                             : getDefaultFoodCategoryImage(food.categoryName)
                         }
-                        style={{ width: 54, height: 54 }}
+                        style={{
+                          width: rv({ sm: ms(42), md: ms(48), lg: ms(48) }),
+                          height: rv({ sm: ms(42), md: ms(48), lg: ms(48) }),
+                        }}
                         resizeMode={hasCustomImage ? "cover" : "contain"}
                       />
                     </View>
@@ -80,14 +88,18 @@ export function CalendarFoodList({
 
                   <YStack f={1}>
                     <Text
-                      fontSize="$5"
+                      fontSize={rv({ sm: fs(13), md: fs(15), lg: fs(15) })}
                       fontWeight="700"
                       color="$mainText"
                       fontFamily="$baemin"
                     >
                       {food.name}
                     </Text>
-                    <Text fontSize="$4" color="$gray10" fontFamily="$baemin">
+                    <Text
+                      fontSize={rv({ sm: fs(12), md: fs(13), lg: fs(13) })}
+                      color="$gray10"
+                      fontFamily="$baemin"
+                    >
                       {getStorageLabel(food.condition.storageType)}{" "}
                       {food.categoryName}
                     </Text>
@@ -100,7 +112,11 @@ export function CalendarFoodList({
                   borderRadius="$6"
                   backgroundColor={badge.color}
                 >
-                  <Text color="white" fontWeight="700" fontSize="$5">
+                  <Text
+                    color="white"
+                    fontWeight="700"
+                    fontSize={rv({ sm: fs(12), md: fs(13), lg: fs(13) })}
+                  >
                     {badge.label}
                   </Text>
                 </View>
@@ -109,7 +125,12 @@ export function CalendarFoodList({
           })
         ) : (
           <YStack ai="center" jc="center" py="$10">
-            <Text color="$gray9" fontSize="$5" fontFamily="$baemin" pt="$5">
+            <Text
+              color="$gray9"
+              fontSize={rv({ sm: fs(13), md: fs(14), lg: fs(14) })}
+              fontFamily="$baemin"
+              pt="$5"
+            >
               해당 날짜에 만료되는 식품이 없습니다.
             </Text>
           </YStack>

--- a/src/features/calendar/components/CalendarMonthView.tsx
+++ b/src/features/calendar/components/CalendarMonthView.tsx
@@ -106,15 +106,17 @@ const styles = StyleSheet.create({
     paddingHorizontal: ms(6),
   },
   dayWrap: {
-    width: rv({ sm: ms(24), md: ms(34), lg: ms(34) }),
-    height: rv({ sm: ms(24), md: ms(40), lg: ms(40) }),
+    // sm에서도 dayCircle + dotRow가 겹치지 않도록 wrapper를 충분히 확보
+    width: rv({ sm: ms(34), md: ms(34), lg: ms(34) }),
+    height: rv({ sm: ms(44), md: ms(40), lg: ms(40) }),
     alignItems: "center",
     justifyContent: "center",
   },
   dayCircle: {
     width: rv({ sm: ms(28), md: ms(30), lg: ms(30) }),
     height: rv({ sm: ms(28), md: ms(30), lg: ms(30) }),
-    borderRadius: rv({ sm: ms(16), md: ms(18), lg: ms(18) }),
+    // 기기별 스케일/반올림 차이로 원형이 깨지는 경우를 방지
+    borderRadius: 9999,
     alignItems: "center",
     justifyContent: "center",
   },
@@ -129,16 +131,16 @@ const styles = StyleSheet.create({
     textAlignVertical: "center",
   },
   dotRow: {
-    minHeight: ms(8),
-    marginTop: ms(2),
+    minHeight: rv({ sm: ms(6), md: ms(8), lg: ms(8) }),
+    marginTop: rv({ sm: ms(1), md: ms(2), lg: ms(2) }),
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
-    gap: ms(2),
+    gap: rv({ sm: ms(1), md: ms(2), lg: ms(2) }),
   },
   dot: {
-    width: s(4),
-    height: s(4),
-    borderRadius: s(2),
+    width: rv({ sm: s(3), md: s(4), lg: s(4) }),
+    height: rv({ sm: s(3), md: s(4), lg: s(4) }),
+    borderRadius: rv({ sm: s(2), md: s(2), lg: s(2) }),
   },
 });

--- a/src/features/calendar/components/CalendarMonthView.tsx
+++ b/src/features/calendar/components/CalendarMonthView.tsx
@@ -1,4 +1,5 @@
 import { getCalendarTheme } from "@/features/calendar/constants/calendarTheme";
+import { fs, ms, rv, s } from "@/shared/constants/layout";
 import { resolveTheme, useThemeStore } from "@/shared/stores/useThemeStore";
 import { ChevronLeft, ChevronRight } from "@tamagui/lucide-icons";
 import React from "react";
@@ -41,9 +42,9 @@ export function CalendarMonthView({
         renderArrow={(direction) => (
           <RNText style={[styles.arrow, { color: arrowColor }]}>
             {direction === "left" ? (
-              <ChevronLeft size={24} color="$mainText" />
+              <ChevronLeft size={s(22)} color="$mainText" />
             ) : (
-              <ChevronRight size={24} color="$mainText" />
+              <ChevronRight size={s(22)} color="$mainText" />
             )}
           </RNText>
         )}
@@ -100,20 +101,20 @@ export function CalendarMonthView({
 
 const styles = StyleSheet.create({
   arrow: {
-    fontSize: 20,
+    fontSize: rv({ sm: fs(14), md: fs(18), lg: fs(18) }),
     fontWeight: "700",
-    paddingHorizontal: 6,
+    paddingHorizontal: ms(6),
   },
   dayWrap: {
-    width: 36,
-    height: 44,
+    width: rv({ sm: ms(24), md: ms(34), lg: ms(34) }),
+    height: rv({ sm: ms(24), md: ms(40), lg: ms(40) }),
     alignItems: "center",
     justifyContent: "center",
   },
   dayCircle: {
-    width: 32,
-    height: 32,
-    borderRadius: 20,
+    width: rv({ sm: ms(28), md: ms(30), lg: ms(30) }),
+    height: rv({ sm: ms(28), md: ms(30), lg: ms(30) }),
+    borderRadius: rv({ sm: ms(16), md: ms(18), lg: ms(18) }),
     alignItems: "center",
     justifyContent: "center",
   },
@@ -122,22 +123,22 @@ const styles = StyleSheet.create({
   },
   dayText: {
     fontFamily: "BMJUA",
-    fontSize: 16,
+    fontSize: rv({ sm: fs(10), md: fs(14), lg: fs(14) }),
     textAlign: "center",
     includeFontPadding: false,
     textAlignVertical: "center",
   },
   dotRow: {
-    minHeight: 8,
-    marginTop: 2,
+    minHeight: ms(8),
+    marginTop: ms(2),
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
-    gap: 2,
+    gap: ms(2),
   },
   dot: {
-    width: 4,
-    height: 4,
-    borderRadius: 2,
+    width: s(4),
+    height: s(4),
+    borderRadius: s(2),
   },
 });

--- a/src/features/calendar/constants/calendarTheme.ts
+++ b/src/features/calendar/constants/calendarTheme.ts
@@ -1,11 +1,13 @@
+import { fs, ms, rv } from "@/shared/constants/layout";
+
 export type CalendarThemeMode = "light" | "dark";
 
 const baseCalendarTheme = {
   textMonthFontFamily: "BMJUA",
   textDayFontFamily: "BMJUA",
   textDayHeaderFontFamily: "BMJUA",
-  textDayFontSize: 16,
-  textMonthFontSize: 22,
+  textDayFontSize: rv({ sm: fs(12), md: fs(14), lg: fs(14) }),
+  textMonthFontSize: rv({ sm: fs(16), md: fs(18), lg: fs(18) }),
 } as const;
 
 const lightCalendarTheme = {
@@ -24,17 +26,17 @@ const lightCalendarTheme = {
     "stylesheet.calendar.header": {
       monthText: {
         fontFamily: "BMJUA",
-        fontSize: 22,
+        fontSize: rv({ sm: fs(16), md: fs(18), lg: fs(18) }),
         color: "#111111",
         fontWeight: "700",
       },
       dayHeader: {
-        marginTop: 8,
-        marginBottom: 10,
-        width: 32,
+        marginTop: ms(8),
+        marginBottom: ms(10),
+        width: ms(30),
         textAlign: "center",
         fontFamily: "BMJUA",
-        fontSize: 16,
+        fontSize: rv({ sm: fs(11), md: fs(13), lg: fs(13) }),
         color: "#111111",
       },
       dayTextAtIndex0: { color: "#8FA7A0" },
@@ -59,17 +61,17 @@ const darkCalendarTheme = {
     "stylesheet.calendar.header": {
       monthText: {
         fontFamily: "BMJUA",
-        fontSize: 22,
+        fontSize: rv({ sm: fs(16), md: fs(18), lg: fs(18) }),
         color: "#E5EBE9",
         fontWeight: "700",
       },
       dayHeader: {
-        marginTop: 8,
-        marginBottom: 10,
-        width: 32,
+        marginTop: ms(8),
+        marginBottom: ms(10),
+        width: ms(30),
         textAlign: "center",
         fontFamily: "BMJUA",
-        fontSize: 16,
+        fontSize: rv({ sm: fs(11), md: fs(13), lg: fs(13) }),
         color: "#E5EBE9",
       },
       dayTextAtIndex0: { color: "#8FA7A0" },

--- a/src/features/food-add/components/CategorySelector/CategoryActionSheet.tsx
+++ b/src/features/food-add/components/CategorySelector/CategoryActionSheet.tsx
@@ -3,7 +3,7 @@ import { Modal, Pressable, StyleSheet } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AnimatePresence, Button, Text, View, XStack, YStack } from "tamagui";
 import { CategoryActionSheetProps } from "../../types";
-import { getBottomPaddingForSheet } from "@/shared/constants/layout";
+import { getBottomPaddingForSheet, ms, s } from "@/shared/constants/layout";
 
 export const CategoryActionSheet = ({
   visible,
@@ -45,8 +45,8 @@ export const CategoryActionSheet = ({
               opacity={1}
             >
               <View
-                w={40}
-                h={5}
+                w={s(40)}
+                h={s(5)}
                 bg="$gray4"
                 br="$4"
                 alignSelf="center"
@@ -74,7 +74,7 @@ export const CategoryActionSheet = ({
                   <Button
                     flex={1}
                     backgroundColor="$gray3"
-                    h={52}
+                    h={ms(48)}
                     br="$4"
                     onPress={onClose}
                     pressStyle={{ scale: 0.97 }}
@@ -88,7 +88,7 @@ export const CategoryActionSheet = ({
                 <YStack gap="$2">
                   <Button
                     backgroundColor="$primary"
-                    h={52}
+                    h={ms(48)}
                     br="$4"
                     onPress={() => {
                       if (!target) return;
@@ -109,7 +109,7 @@ export const CategoryActionSheet = ({
 
                   <Button
                     backgroundColor="$warning"
-                    h={52}
+                    h={ms(48)}
                     br="$4"
                     onPress={() => {
                       if (!target) return;
@@ -125,7 +125,7 @@ export const CategoryActionSheet = ({
 
                   <Button
                     backgroundColor="$gray3"
-                    h={52}
+                    h={ms(48)}
                     br="$4"
                     onPress={onClose}
                     pressStyle={{ scale: 0.97 }}

--- a/src/features/food-add/components/CategorySelector/CategoryFormSheet.tsx
+++ b/src/features/food-add/components/CategorySelector/CategoryFormSheet.tsx
@@ -19,7 +19,7 @@ import {
   YStack,
 } from "tamagui";
 import { CategoryFormSheetProps, CategoryFormValues } from "../../types";
-import { getBottomPaddingForSheet } from "@/shared/constants/layout";
+import { getBottomPaddingForSheet, ms, s } from "@/shared/constants/layout";
 
 export const CategoryFormSheet = ({
   visible,
@@ -133,8 +133,8 @@ export const CategoryFormSheet = ({
                 opacity={1}
               >
                 <View
-                  w={40}
-                  h={5}
+                  w={s(40)}
+                  h={s(5)}
                   bg="$gray4"
                   br="$4"
                   alignSelf="center"
@@ -157,7 +157,7 @@ export const CategoryFormSheet = ({
                     render={({ field: { onChange, value } }) => (
                       <Input
                         autoFocus={!isEditMode}
-                        h={52}
+                        h={ms(48)}
                         placeholder={
                           isEditMode ? "카테고리 이름" : "새 카테고리 이름"
                         }
@@ -180,7 +180,7 @@ export const CategoryFormSheet = ({
                   <Button
                     flex={1}
                     backgroundColor="$primary"
-                    h={52}
+                    h={ms(48)}
                     br="$4"
                     onPress={handleSubmit(onSubmit)}
                     disabled={isPending}

--- a/src/features/food-add/components/CategorySelector/CategorySelector.tsx
+++ b/src/features/food-add/components/CategorySelector/CategorySelector.tsx
@@ -10,8 +10,13 @@ import { useUpdateCategoryMutation } from "../../hooks/mutations/useUpdateCatego
 import { Category, CategorySelectorProps } from "../../types";
 import { CategoryActionSheet } from "./CategoryActionSheet";
 import { CategoryFormSheet } from "./CategoryFormSheet";
+import { fs, ms } from "@/shared/constants/layout";
 
-const LabelText = styled(Text, { fontSize: 18, fontWeight: "700", mb: "$2" });
+const LabelText = styled(Text, {
+  fontSize: ms(16),
+  fontWeight: "700",
+  mb: "$2",
+});
 
 export const CategorySelector = ({
   control,
@@ -128,8 +133,11 @@ export const CategorySelector = ({
                 fontFamily="$baemin"
                 fontSize="$3"
                 px="$4"
+                h={ms(40)}
               >
-                {cat.name}
+                <Text fontFamily="$baemin" fontSize={fs(13)} fontWeight="700">
+                  {cat.name}
+                </Text>
               </Button>
             </Pressable>
           ))}
@@ -141,8 +149,9 @@ export const CategorySelector = ({
             br="$4"
             px="$4"
             onPress={openAddSheet}
+            h={ms(40)}
           >
-            <Text fontFamily="$baemin" fontSize="$3" color="$mainText">
+            <Text fontFamily="$baemin" fontSize={fs(13)} color="$mainText">
               추가
             </Text>
           </Button>

--- a/src/features/food-add/components/ExpiryDatePicker/DateSelectSheet.tsx
+++ b/src/features/food-add/components/ExpiryDatePicker/DateSelectSheet.tsx
@@ -12,7 +12,7 @@ import {
   styled,
 } from "tamagui";
 import { DateSelectSheetProps } from "../../types";
-import { getBottomPaddingForSheet } from "@/shared/constants/layout";
+import { fs, getBottomPaddingForSheet, s } from "@/shared/constants/layout";
 
 const Overlay = styled(View, {
   position: "absolute",
@@ -89,8 +89,8 @@ export const DateSelectSheet = ({
                 opacity={1}
               >
                 <View
-                  w={40}
-                  h={5}
+                  w={s(40)}
+                  h={s(5)}
                   bg="$gray5"
                   br="$4"
                   alignSelf="center"
@@ -99,13 +99,15 @@ export const DateSelectSheet = ({
                 />
                 <XStack jc="space-between" ai="center" p="$4">
                   <Button chromeless onPress={onClose}>
-                    <Text color="$gray10">취소</Text>
+                    <Text color="$gray10" fontSize={fs(14)}>
+                      취소
+                    </Text>
                   </Button>
-                  <Text fontWeight="800" fontSize="$5">
+                  <Text fontWeight="800" fontSize={fs(16)}>
                     날짜 선택
                   </Text>
                   <Button chromeless onPress={onClose}>
-                    <Text color="$primary" fontWeight="800">
+                    <Text color="$primary" fontWeight="800" fontSize={fs(14)}>
                       확인
                     </Text>
                   </Button>

--- a/src/features/food-add/components/ExpiryDatePicker/ExpiryDatePicker.tsx
+++ b/src/features/food-add/components/ExpiryDatePicker/ExpiryDatePicker.tsx
@@ -4,6 +4,7 @@ import { Controller } from "react-hook-form";
 import { Button, Text, XStack, styled } from "tamagui";
 import { FoodFormProps } from "../../types";
 import { DateSelectSheet } from "./DateSelectSheet";
+import { fs, ms, s } from "@/shared/constants/layout";
 
 const LabelText = styled(Text, {
   fontFamily: "$heading",
@@ -41,13 +42,13 @@ export const ExpiryDatePicker = ({ control }: FoodFormProps) => {
               backgroundColor="$gray3"
               br="$4"
               px="$4"
-              h={52}
+              h={ms(44)}
               pressStyle={{ scale: 0.97, bg: "$gray4" }}
-              iconAfter={<Calendar size={18} color="$primary" />}
+              iconAfter={<Calendar size={s(16)} color="$primary" />}
               onPress={() => setShow(true)}
               borderWidth={1}
             >
-              <Text fontSize="$4" fontWeight="600" color="$mainText">
+              <Text fontSize={fs(14)} fontWeight="600" color="$mainText">
                 {formatDate(value || new Date())}
               </Text>
             </Button>

--- a/src/features/food-add/components/FoodNameInput.tsx
+++ b/src/features/food-add/components/FoodNameInput.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Control, Controller } from "react-hook-form";
 import { Input, Text, YStack, styled, useThemeName } from "tamagui";
 import { FoodFormValues } from "../types";
+import { ms } from "@/shared/constants/layout";
 
 const LabelText = styled(Text, {
   fontFamily: "$heading",
@@ -36,7 +37,7 @@ export const FoodNameInput = ({
             </Text>
           )}
           <Input
-            h={50}
+            h={ms(44)}
             value={value}
             onChangeText={onChange}
             placeholder="식품 이름을 입력하세요"

--- a/src/features/food-add/components/ImageUploader.tsx
+++ b/src/features/food-add/components/ImageUploader.tsx
@@ -3,6 +3,7 @@ import * as ImagePicker from "expo-image-picker";
 import { Control, Controller } from "react-hook-form";
 import { Circle, Image, Text, YStack } from "tamagui";
 import { FoodFormValues } from "../types";
+import { fs, ms, s } from "@/shared/constants/layout";
 
 export const ImageUploader = ({
   control,
@@ -37,7 +38,7 @@ export const ImageUploader = ({
       name="imageURL"
       render={({ field: { onChange, value } }) => (
         <YStack
-          h={200}
+          h={ms(170)}
           backgroundColor="$gray3"
           br="$5"
           bw={1}
@@ -57,14 +58,15 @@ export const ImageUploader = ({
             />
           ) : (
             <YStack ai="center">
-              <Circle size={56} backgroundColor="$background" elevation="$1">
-                <Camera size={28} color="$gray" />
+              <Circle size={s(52)} backgroundColor="$background" elevation="$1">
+                <Camera size={s(24)} color="$gray" />
               </Circle>
               <Text
                 fontFamily="$heading"
                 mt="$2"
                 color="$gray"
                 fontWeight="700"
+                fontSize={fs(14)}
               >
                 이미지 등록
               </Text>

--- a/src/features/food-add/components/QuantityInput/QuantityInput.tsx
+++ b/src/features/food-add/components/QuantityInput/QuantityInput.tsx
@@ -53,7 +53,10 @@ export const QuantityInput = ({
                   br="$2"
                   bg="$surface"
                   icon={<Minus size={s(14)} />}
-                  onPress={() => onChange(normalizeQuantity(value) - 1)}
+                  onPress={() => {
+                    const next = normalizeQuantity(value) - 1;
+                    onChange(normalizeQuantity(next));
+                  }}
                 />
                 <Input
                   w={ms(46)}
@@ -93,7 +96,10 @@ export const QuantityInput = ({
                   br="$2"
                   bg="$surface"
                   icon={<Plus size={s(14)} />}
-                  onPress={() => onChange(normalizeQuantity(value) + 1)}
+                  onPress={() => {
+                    const next = normalizeQuantity(value) + 1;
+                    onChange(normalizeQuantity(next));
+                  }}
                 />
               </>
             )}

--- a/src/features/food-add/components/QuantityInput/QuantityInput.tsx
+++ b/src/features/food-add/components/QuantityInput/QuantityInput.tsx
@@ -5,6 +5,7 @@ import { Keyboard } from "react-native";
 import { Button, Input, Text, XStack, styled } from "tamagui";
 import { QuantityInputProps } from "../../types";
 import { UnitSelector } from "./UnitSelector";
+import { fs, ms, s } from "@/shared/constants/layout";
 
 const LabelText = styled(Text, {
   fontFamily: "$heading",
@@ -30,7 +31,9 @@ export const QuantityInput = ({
 }: QuantityInputProps) => {
   return (
     <XStack ai="center" jc="space-between">
-      <LabelText>수량 및 단위</LabelText>
+      <LabelText fontFamily="$baemin" fontSize={fs(14)}>
+        수량 및 단위
+      </LabelText>
 
       <XStack gap="$3" ai="center">
         <XStack backgroundColor="$gray3" br="$4" p="$2" ai="center" gap="$3">
@@ -45,20 +48,20 @@ export const QuantityInput = ({
             render={({ field: { onChange, value } }) => (
               <>
                 <Button
-                  w={25}
-                  h={30}
+                  w={ms(20)}
+                  h={ms(26)}
                   br="$2"
                   bg="$surface"
-                  icon={<Minus size={16} />}
+                  icon={<Minus size={s(14)} />}
                   onPress={() => onChange(normalizeQuantity(value) - 1)}
                 />
                 <Input
-                  w={56}
-                  h={36}
+                  w={ms(46)}
+                  h={ms(28)}
                   p={0}
                   ta="center"
                   fontFamily="$baemin"
-                  fontSize="$4"
+                  fontSize={fs(14)}
                   fontWeight="700"
                   keyboardType="number-pad"
                   returnKeyType="done"
@@ -85,11 +88,11 @@ export const QuantityInput = ({
                   onSubmitEditing={() => Keyboard.dismiss()}
                 />
                 <Button
-                  w={25}
-                  h={30}
+                  w={ms(20)}
+                  h={ms(26)}
                   br="$2"
                   bg="$surface"
-                  icon={<Plus size={16} />}
+                  icon={<Plus size={s(14)} />}
                   onPress={() => onChange(normalizeQuantity(value) + 1)}
                 />
               </>

--- a/src/features/food-add/components/QuantityInput/UnitSelector.tsx
+++ b/src/features/food-add/components/QuantityInput/UnitSelector.tsx
@@ -1,5 +1,5 @@
 import { UNIT_OPTIONS } from "@/shared/constants/food";
-import { getBottomPaddingForSheet, fs, ms, s } from "@/shared/constants/layout";
+import { fs, getBottomPaddingForSheet, ms, s } from "@/shared/constants/layout";
 import { ChevronDown } from "@tamagui/lucide-icons";
 import React, { useState } from "react";
 import { Modal } from "react-native";
@@ -38,7 +38,7 @@ export const UnitSelector = ({ value, onChange }: any) => {
   return (
     <>
       <Button
-        h={ms(38)}
+        h={ms(44)}
         minWidth={ms(76)}
         bg="$gray3"
         br="$4"
@@ -101,10 +101,14 @@ export const UnitSelector = ({ value, onChange }: any) => {
                         bg={value === option.value ? "$primary" : "$gray3"}
                         br="$4"
                         px="$4"
-                        h={ms(40)}
+                        h={ms(44)}
                         pressStyle={{ scale: 0.95 }}
                       >
-                        <Text color="$mainText" fontWeight="700" fontSize={fs(13)}>
+                        <Text
+                          color="$mainText"
+                          fontWeight="700"
+                          fontSize={fs(13)}
+                        >
                           {option.label}
                         </Text>
                       </Button>

--- a/src/features/food-add/components/QuantityInput/UnitSelector.tsx
+++ b/src/features/food-add/components/QuantityInput/UnitSelector.tsx
@@ -1,5 +1,5 @@
 import { UNIT_OPTIONS } from "@/shared/constants/food";
-import { getBottomPaddingForSheet } from "@/shared/constants/layout";
+import { getBottomPaddingForSheet, fs, ms, s } from "@/shared/constants/layout";
 import { ChevronDown } from "@tamagui/lucide-icons";
 import React, { useState } from "react";
 import { Modal } from "react-native";
@@ -38,14 +38,14 @@ export const UnitSelector = ({ value, onChange }: any) => {
   return (
     <>
       <Button
-        h={52}
-        minWidth={90}
+        h={ms(38)}
+        minWidth={ms(76)}
         bg="$gray3"
         br="$4"
         onPress={() => setShow(true)}
-        iconAfter={<ChevronDown size={16} color="$gray9" />}
+        iconAfter={<ChevronDown size={s(13)} color="$gray9" />}
       >
-        <Text fontSize="$4" color="$mainText" fontFamily="$baemin">
+        <Text fontSize={fs(13)} color="$mainText" fontFamily="$baemin">
           {value.label || currentLabel}
         </Text>
       </Button>
@@ -79,8 +79,8 @@ export const UnitSelector = ({ value, onChange }: any) => {
                   opacity={1}
                 >
                   <View
-                    w={40}
-                    h={5}
+                    w={s(40)}
+                    h={s(5)}
                     bg="$gray4"
                     br="$4"
                     alignSelf="center"
@@ -101,10 +101,10 @@ export const UnitSelector = ({ value, onChange }: any) => {
                         bg={value === option.value ? "$primary" : "$gray3"}
                         br="$4"
                         px="$4"
-                        h={45}
+                        h={ms(40)}
                         pressStyle={{ scale: 0.95 }}
                       >
-                        <Text color="$mainText" fontWeight="700">
+                        <Text color="$mainText" fontWeight="700" fontSize={fs(13)}>
                           {option.label}
                         </Text>
                       </Button>

--- a/src/features/food-add/components/StorageSelector.tsx
+++ b/src/features/food-add/components/StorageSelector.tsx
@@ -1,9 +1,9 @@
+import { fs, ms } from "@/shared/constants/layout";
 import { StorageType } from "@/shared/types/food";
 import React from "react";
 import { Control, Controller } from "react-hook-form";
 import { Button, Text, XStack, YStack, styled } from "tamagui";
 import { FoodFormValues } from "../types";
-import { fs, ms } from "@/shared/constants/layout";
 
 const LabelText = styled(Text, {
   fontFamily: "$heading",
@@ -41,7 +41,7 @@ export const StorageSelector = ({
               chromeless={value !== storageValue}
               br="$3"
               size="$4"
-              h={ms(40)}
+              h={ms(44)}
             >
               <Text fontFamily="$baemin" fontSize={fs(14)} fontWeight="700">
                 {label}

--- a/src/features/food-add/components/StorageSelector.tsx
+++ b/src/features/food-add/components/StorageSelector.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Control, Controller } from "react-hook-form";
 import { Button, Text, XStack, YStack, styled } from "tamagui";
 import { FoodFormValues } from "../types";
+import { fs, ms } from "@/shared/constants/layout";
 
 const LabelText = styled(Text, {
   fontFamily: "$heading",
@@ -39,9 +40,12 @@ export const StorageSelector = ({
               onPress={() => onChange(storageValue)}
               chromeless={value !== storageValue}
               br="$3"
-              size="$5"
+              size="$4"
+              h={ms(40)}
             >
-              {label}
+              <Text fontFamily="$baemin" fontSize={fs(14)} fontWeight="700">
+                {label}
+              </Text>
             </Button>
           ))}
         </XStack>

--- a/src/features/food-add/screens/FoodAddScreen.tsx
+++ b/src/features/food-add/screens/FoodAddScreen.tsx
@@ -13,7 +13,7 @@ import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Toast from "react-native-toast-message";
 import { Button, ScrollView, Text, XStack, YStack } from "tamagui";
-import { getBottomPaddingForSheet } from "@/shared/constants/layout";
+import { fs, getBottomPaddingForSheet, vs } from "@/shared/constants/layout";
 import { CategorySelector } from "../components/CategorySelector/CategorySelector";
 import { ExpiryDatePicker } from "../components/ExpiryDatePicker/ExpiryDatePicker";
 import { FoodNameInput } from "../components/FoodNameInput";
@@ -24,7 +24,7 @@ import { useAddFoodMutation } from "../hooks/mutations/useAddFoodMutation";
 import { useCategoryQuery } from "../hooks/queries/useCategoryQuery";
 import { FoodFormValues } from "../types";
 
-const EXTRA_SCROLL_HEIGHT = 180;
+const EXTRA_SCROLL_HEIGHT = vs(150);
 
 export function FoodAddScreen() {
   const insets = useSafeAreaInsets();
@@ -227,7 +227,7 @@ export function FoodAddScreen() {
             <Text
               color="$mainText"
               fontWeight="700"
-              fontSize="$5"
+              fontSize={fs(16)}
               fontFamily="$baemin"
             >
               식품 등록

--- a/src/features/food-detail/components/FoodDetail/FoodDetailCard.tsx
+++ b/src/features/food-detail/components/FoodDetail/FoodDetailCard.tsx
@@ -9,6 +9,7 @@ import { Text, View, XStack, YStack } from "tamagui";
 import { FOOD_STATUS_TEXT } from "../../constants";
 import { FoodDetailCardProps } from "../../types";
 import { FoodDetailCardRow } from "./FoodDetailCardRow";
+import { fs, ms } from "@/shared/constants/layout";
 
 export function FoodDetailCard({ food }: FoodDetailCardProps) {
   const statusColor = FOOD_STATUS_LABELS[food.condition.foodStatus];
@@ -29,7 +30,7 @@ export function FoodDetailCard({ food }: FoodDetailCardProps) {
           <Text
             color="$mainText"
             fontWeight="800"
-            fontSize="$6"
+            fontSize={fs(18)}
             fontFamily="$baemin"
             flex={1}
           >
@@ -37,13 +38,23 @@ export function FoodDetailCard({ food }: FoodDetailCardProps) {
           </Text>
 
           <View px="$3" py="$1" br="$6" bg={statusBgColor}>
-            <Text color={statusColor} fontWeight="700" fontFamily="$baemin">
+            <Text
+              color={statusColor}
+              fontWeight="700"
+              fontFamily="$baemin"
+              fontSize={fs(12)}
+            >
               {statusText}
             </Text>
           </View>
         </XStack>
 
-        <Text color="$gray10" fontFamily="$baemin" fontSize="$4">
+        <Text
+          color="$gray10"
+          fontFamily="$baemin"
+          fontSize={fs(13)}
+          lineHeight={ms(18)}
+        >
           {food.description || "식품 설명이 없습니다."}
         </Text>
       </YStack>

--- a/src/features/food-detail/components/FoodDetail/FoodDetailCardRow.tsx
+++ b/src/features/food-detail/components/FoodDetail/FoodDetailCardRow.tsx
@@ -1,15 +1,16 @@
 import { Text, XStack } from "tamagui";
 import { FoodDetailCardRowProps } from "../../types";
+import { fs } from "@/shared/constants/layout";
 
 export function FoodDetailCardRow({ label, value }: FoodDetailCardRowProps) {
   return (
     <XStack jc="space-between" ai="center" py="$3">
-      <Text color="$primary" fontSize="$4" fontFamily="$baemin">
+      <Text color="$primary" fontSize={fs(13)} fontFamily="$baemin">
         {label}
       </Text>
       <Text
         color="$mainText"
-        fontSize="$4"
+        fontSize={fs(13)}
         fontWeight="700"
         fontFamily="$baemin"
       >

--- a/src/features/food-detail/screens/FoodDetailScreen.tsx
+++ b/src/features/food-detail/screens/FoodDetailScreen.tsx
@@ -1,5 +1,5 @@
 import { Header } from "@/shared/components/Header/Header";
-import { getBottomPaddingForSheet } from "@/shared/constants/layout";
+import { fs, getBottomPaddingForSheet, ms } from "@/shared/constants/layout";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Button, ScrollView, Spinner, Text, YStack } from "tamagui";
@@ -90,6 +90,7 @@ export function FoodDetailScreen() {
             backgroundColor="$primary"
             size="$5"
             br="$3"
+            h={ms(48)}
             onPress={() => {
               router.push({
                 pathname: "/food-edit",
@@ -103,7 +104,7 @@ export function FoodDetailScreen() {
             <Text
               color="$mainText"
               fontWeight="700"
-              fontSize="$4"
+              fontSize={fs(14)}
               fontFamily="$baemin"
             >
               수정하기

--- a/src/features/food-edit/screens/FoodEditScreen.tsx
+++ b/src/features/food-edit/screens/FoodEditScreen.tsx
@@ -8,7 +8,7 @@ import { FoodFormValues } from "@/features/food-add/types";
 import { useFoodDetailQuery } from "@/features/food-detail/hooks/queries/useFoodDetailQuery";
 import { parseParamToNumber } from "@/features/food-detail/utils/params";
 import { Header } from "@/shared/components/Header/Header";
-import { getBottomPaddingForSheet } from "@/shared/constants/layout";
+import { getBottomPaddingForSheet, ms } from "@/shared/constants/layout";
 import { useLocalSearchParams } from "expo-router";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
@@ -220,7 +220,7 @@ export function FoodEditScreen() {
               <YStack>
                 <LabelText>메모</LabelText>
                 <Input
-                  h={50}
+                  h={ms(44)}
                   value={value || ""}
                   onChangeText={onChange}
                   placeholder="메모를 입력하세요"

--- a/src/features/fridge-management/components/FridgeNameEditSheet.tsx
+++ b/src/features/fridge-management/components/FridgeNameEditSheet.tsx
@@ -9,7 +9,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AnimatePresence, Button, Input, Text, View, YStack } from "tamagui";
 import { FridgeNameEditSheetProps } from "../types";
-import { getBottomPaddingForSheet } from "@/shared/constants/layout";
+import { fs, getBottomPaddingForSheet, ms, s } from "@/shared/constants/layout";
 
 export const FridgeNameEditSheet = ({
   visible,
@@ -78,7 +78,13 @@ export const FridgeNameEditSheet = ({
                 y={0}
                 opacity={1}
               >
-                <View w={40} h={5} bg="$gray4" br="$4" alignSelf="center" />
+                <View
+                  w={s(40)}
+                  h={s(5)}
+                  bg="$gray4"
+                  br="$4"
+                  alignSelf="center"
+                />
 
                 <YStack gap="$2">
                   <Text fontSize="$6" fontWeight="700" fontFamily="$baemin">
@@ -108,10 +114,15 @@ export const FridgeNameEditSheet = ({
                       !newName.trim() || newName === currentName || isLoading
                     }
                     onPress={handleSave}
-                    h={56}
+                    h={ms(48)}
                     br="$4"
                   >
-                    <Text color="$mainText" fontWeight="700" fontSize={16}>
+                    <Text
+                      color="$mainText"
+                      fontWeight="700"
+                      fontSize={fs(15)}
+                      fontFamily="$baemin"
+                    >
                       {isLoading ? "수정 중..." : "수정 완료"}
                     </Text>
                   </Button>

--- a/src/features/fridge-management/components/FridgeSelectionSheet.tsx
+++ b/src/features/fridge-management/components/FridgeSelectionSheet.tsx
@@ -13,7 +13,7 @@ import {
   YStack,
 } from "tamagui";
 import { FridgeSelectionProps } from "../types";
-import { getBottomPaddingForSheet } from "@/shared/constants/layout";
+import { fs, getBottomPaddingForSheet, ms, s } from "@/shared/constants/layout";
 
 export const FridgeSelectionSheet = ({
   visible,
@@ -67,8 +67,8 @@ export const FridgeSelectionSheet = ({
               maxHeight="70%"
             >
               <View
-                w={40}
-                h={5}
+                w={s(40)}
+                h={s(5)}
                 bg="$gray4"
                 br="$4"
                 alignSelf="center"
@@ -98,20 +98,20 @@ export const FridgeSelectionSheet = ({
                         <XStack gap="$3" ai="center">
                           <View p="$2" br="$2" backgroundColor="$gray2">
                             <Refrigerator
-                              size={28}
+                              size={s(24)}
                               color={isSelected ? "$primary" : "$gray10"}
                             />
                           </View>
                           <YStack>
                             <Text
                               fontWeight="700"
-                              fontSize={16}
+                              fontSize={fs(14)}
                               fontFamily="$baemin"
                             >
                               {fridge.name}
                             </Text>
                             <Text
-                              fontSize={12}
+                              fontSize={fs(12)}
                               color="$primary"
                               fontWeight="600"
                             >
@@ -121,8 +121,8 @@ export const FridgeSelectionSheet = ({
                         </XStack>
 
                         {isSelected && (
-                          <Circle size={24} bc="$primary">
-                            <Check size={16} color="$white" />
+                          <Circle size={s(22)} bc="$primary">
+                            <Check size={s(14)} color="$white" />
                           </Circle>
                         )}
                       </XStack>
@@ -146,11 +146,12 @@ export const FridgeSelectionSheet = ({
                       router.push("/fridge-add");
                     }}
                   >
-                    <PlusCircle size={20} color="$mainText" />
+                    <PlusCircle size={s(18)} color="$mainText" />
                     <Text
                       color="$mainText"
                       fontWeight="600"
                       fontFamily="$baemin"
+                      fontSize={fs(14)}
                     >
                       새 냉장고 추가
                     </Text>

--- a/src/features/fridge-management/components/InviteModal.tsx
+++ b/src/features/fridge-management/components/InviteModal.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Modal } from "react-native";
 import { Button, Text, View, XStack, YStack } from "tamagui";
 import { InviteModalProps } from "../types";
+import { fs, ms, s } from "@/shared/constants/layout";
 
 export const InviteModal = ({
   visible,
@@ -30,7 +31,7 @@ export const InviteModal = ({
           elevation={10}
         >
           <XStack w="100%" jc="flex-end">
-            <X size={24} color="$gray10" onPress={onClose} />
+            <X size={s(22)} color="$gray10" onPress={onClose} />
           </XStack>
 
           <YStack ai="center" gap="$2">
@@ -59,41 +60,41 @@ export const InviteModal = ({
             ai="center"
             gap="$2"
           >
-            <Text color="$blue10" fontSize={12} fontWeight="700" ls={1}>
+            <Text color="$blue10" fontSize={fs(12)} fontWeight="700" ls={1}>
               INVITATION CODE
             </Text>
-            <Text fontSize={32} fontWeight="900" fontFamily="$baemin" ls={2}>
+            <Text fontSize={fs(28)} fontWeight="900" fontFamily="$baemin" ls={2}>
               {inviteCode}
             </Text>
           </YStack>
 
-          <Text color="$gray9" fontSize={12}>
+          <Text color="$gray9" fontSize={fs(12)}>
             이 코드는 발급 후 24시간 동안 유효합니다.
           </Text>
 
           <YStack w="100%" gap="$3">
             <Button
               bg="#FEE500"
-              h={56}
+              h={ms(50)}
               br="$4"
               pressStyle={{ opacity: 0.8 }}
               onPress={onShareKakao}
-              icon={<MessageCircle size={20} color="$black" fill="black" />}
+              icon={<MessageCircle size={s(18)} color="$black" fill="black" />}
             >
-              <Text fontWeight="700" color="$black">
+              <Text fontWeight="700" color="$black" fontSize={fs(14)}>
                 카카오톡으로 공유
               </Text>
             </Button>
 
             <Button
               bg="$primary"
-              h={56}
+              h={ms(50)}
               br="$4"
               pressStyle={{ opacity: 0.8 }}
               onPress={onCopy}
-              icon={<Copy size={20} color="$white" />}
+              icon={<Copy size={s(18)} color="$white" />}
             >
-              <Text color="$white" fontWeight="700">
+              <Text color="$white" fontWeight="700" fontSize={fs(14)}>
                 코드 복사하기
               </Text>
             </Button>

--- a/src/features/fridge-management/screens/FridgeAddScreen.tsx
+++ b/src/features/fridge-management/screens/FridgeAddScreen.tsx
@@ -2,6 +2,7 @@ import { Header } from "@/shared/components/Header/Header";
 import { useState } from "react";
 import { Button, Input, Text, YStack } from "tamagui";
 import { useJoinFridgeByInviteCodeMutation } from "../hooks/mutations/useJoinFridgeByInviteCodeMutation";
+import { fs, ms } from "@/shared/constants/layout";
 
 export function FridgeAddScreen() {
   const [inviteCode, setInviteCode] = useState("");
@@ -23,17 +24,17 @@ export function FridgeAddScreen() {
       <Header title="냉장고 추가" showBackButton />
       <YStack p="$5" gap="$5">
         <YStack gap="$2">
-          <Text fontSize="$6" fontWeight="700" fontFamily="$baemin">
+          <Text fontSize={fs(18)} fontWeight="700" fontFamily="$baemin">
             초대코드를 입력해주세요
           </Text>
-          <Text color="$gray10">
+          <Text color="$gray10" fontSize={fs(13)} fontFamily="$baemin">
             전달받은 코드를 입력하면 냉장고에 참여할 수 있어요.
           </Text>
         </YStack>
 
         <Input
           fontFamily="$baemin"
-          h={60}
+          h={ms(50)}
           br="$4"
           fontSize="$5"
           placeholder="초대코드 입력"
@@ -46,10 +47,10 @@ export function FridgeAddScreen() {
         <Button
           bc="$primary"
           color="$white"
-          h={56}
+          h={ms(48)}
           br="$4"
           fontWeight="700"
-          fontSize="$4"
+          fontSize={fs(15)}
           onPress={handleJoin}
           disabled={isPending || inviteCode.length !== 8}
         >

--- a/src/features/fridge-management/screens/FridgeManagementScreen.tsx
+++ b/src/features/fridge-management/screens/FridgeManagementScreen.tsx
@@ -25,6 +25,7 @@ import { useUpdateFridgeNameMutation } from "../hooks/mutations/useUpdateFridgeN
 import { useFridgeDetailQuery } from "../hooks/queries/useFridgeDetailQuery";
 import { useFridgeListQuery } from "../hooks/queries/useFridgeListQuery";
 import { useFridgeMembersQuery } from "../hooks/queries/useFridgeMembersQuery";
+import { fs, ms, s } from "@/shared/constants/layout";
 
 // NOTE: 카카오톡 공유 기능은 후에 고도화 예정
 
@@ -155,7 +156,7 @@ export function FridgeManagementScreen() {
             <>
               <YStack ai="center" py="$8" gap="$3">
                 <View p="$4" br="$6" bc="$surface" mb="$2">
-                  <Refrigerator size={48} color="$primary" />
+                  <Refrigerator size={s(40)} color="$primary" />
                 </View>
 
                 <XStack
@@ -164,19 +165,19 @@ export function FridgeManagementScreen() {
                   onPress={() => setSheetOpen(true)}
                   pressStyle={{ opacity: 0.7 }}
                 >
-                  <Text fontSize={24} fontWeight="900" fontFamily="$baemin">
+                  <Text fontSize={fs(20)} fontWeight="900" fontFamily="$baemin">
                     {fridgeInfo.data.name}
                   </Text>
-                  <ChevronDown size={20} color="$mainText" />
+                  <ChevronDown size={s(18)} color="$mainText" />
                 </XStack>
               </YStack>
 
               <YStack px="$5" gap="$3">
                 <XStack jc="space-between" ai="center">
-                  <Text fontSize={16} fontWeight="700" fontFamily="$baemin">
+                  <Text fontSize={fs(15)} fontWeight="700" fontFamily="$baemin">
                     참여 멤버
                   </Text>
-                  <Text color="$gray9" fontSize={14}>
+                  <Text color="$gray9" fontSize={fs(13)} fontFamily="$baemin">
                     {members.length}명
                   </Text>
                 </XStack>
@@ -196,10 +197,10 @@ export function FridgeManagementScreen() {
                 <Button
                   bc="$primary"
                   color="$white"
-                  h={56}
+                  h={ms(48)}
                   br="$4"
                   fontWeight="700"
-                  fontSize={16}
+                  fontSize={fs(15)}
                   onPress={handleGenerateInviteCode}
                   disabled={isGenerating}
                 >
@@ -209,7 +210,7 @@ export function FridgeManagementScreen() {
                 <YStack ai="center" gap="$4" py="$2">
                   <Text
                     color="$gray10"
-                    fontSize={14}
+                    fontSize={fs(13)}
                     onPress={() => openConfirmModal("leave")}
                   >
                     냉장고 나가기
@@ -217,7 +218,7 @@ export function FridgeManagementScreen() {
                   {fridgeInfo.data.isOwner && (
                     <Text
                       color="$gray10"
-                      fontSize={14}
+                      fontSize={fs(13)}
                       onPress={handleEditName}
                     >
                       냉장고 이름 수정
@@ -226,7 +227,7 @@ export function FridgeManagementScreen() {
                   {fridgeInfo.data.isOwner && (
                     <Text
                       color="$warning"
-                      fontSize={14}
+                      fontSize={fs(13)}
                       onPress={() => openConfirmModal("delete")}
                     >
                       냉장고 삭제

--- a/src/features/home/components/CategoryTabs.tsx
+++ b/src/features/home/components/CategoryTabs.tsx
@@ -1,4 +1,5 @@
 import { STORAGE_TABS } from "@/shared/constants/food";
+import { fs, rv, s } from "@/shared/constants/layout";
 import { Text, View, XStack, YStack } from "tamagui";
 import { CategoryTabsProps } from "../types";
 
@@ -11,16 +12,16 @@ export function CategoryTabs({ activeTab, onTabChange }: CategoryTabsProps) {
           return (
             <View
               key={tab}
-              pb="$3"
+              pb={rv({ sm: "$2", md: "$3", lg: "$3" })}
               px="$2"
               onPress={() => onTabChange(tab)}
               style={{ position: "relative" }}
             >
               <Text
                 fontFamily="$baemin"
-                fontSize="$5"
+                fontSize={rv({ sm: fs(14), md: fs(16), lg: fs(16) })}
                 fontWeight="700"
-                color={isActive ? "$secondary" : "$gray"}
+                color={isActive ? "$primary" : "$gray"}
               >
                 {tab}
               </Text>
@@ -31,8 +32,8 @@ export function CategoryTabs({ activeTab, onTabChange }: CategoryTabsProps) {
                   bottom={0}
                   left={0}
                   right={0}
-                  height={3}
-                  backgroundColor="$secondary"
+                  height={s(3)}
+                  backgroundColor="$primary"
                 />
               )}
             </View>

--- a/src/features/home/components/Expiry/Expiry.tsx
+++ b/src/features/home/components/Expiry/Expiry.tsx
@@ -1,3 +1,4 @@
+import { ms, rv, s } from "@/shared/constants/layout";
 import {
   AlertCircle,
   AlertTriangle,
@@ -15,49 +16,57 @@ export function Expiry({ activeStatus, onStatusChange, counts }: ExpiryProps) {
       bordered
       backgroundColor="$surface"
       borderRadius="$3"
-      p="$4"
+      p={rv({ sm: "$2", md: "$3", lg: "$3" })}
       mx="$4"
     >
-      <XStack jc="space-around" ai="center">
-        <StatusItem
-          icon={<XCircle size={14} color="$expired" />}
-          label="만료"
-          count={counts.BLACK.toString()}
-          sub="만료"
-          color="$expired"
-          onPress={() => onStatusChange("BLACK")}
-          opacity={activeStatus && activeStatus !== "BLACK" ? 0.3 : 1}
-        />
-        <Separator vertical height={60} opacity={1} />
-        <StatusItem
-          icon={<AlertCircle size={14} color="$warning" />}
-          label="임박"
-          count={counts.RED.toString()}
-          sub="10일 이내"
-          color="$warning"
-          onPress={() => onStatusChange("RED")}
-          opacity={activeStatus && activeStatus !== "RED" ? 0.3 : 1}
-        />
-        <Separator vertical height={60} opacity={1} />
-        <StatusItem
-          icon={<AlertTriangle size={14} color="$alert" />}
-          label="주의"
-          count={counts.YELLOW.toString()}
-          sub="20일 이내"
-          color="$alert"
-          onPress={() => onStatusChange("YELLOW")}
-          opacity={activeStatus && activeStatus !== "YELLOW" ? 0.3 : 1}
-        />
-        <Separator vertical height={60} opacity={1} />
-        <StatusItem
-          icon={<CheckCircle size={14} color="$success" />}
-          label="양호"
-          count={counts.GREEN.toString()}
-          sub="양호"
-          color="$success"
-          onPress={() => onStatusChange("GREEN")}
-          opacity={activeStatus && activeStatus !== "GREEN" ? 0.3 : 1}
-        />
+      <XStack ai="stretch" jc="space-between">
+        <XStack f={1} minWidth={0} jc="center">
+          <StatusItem
+            icon={<XCircle size={s(13)} color="$expired" />}
+            label="만료"
+            count={counts.BLACK.toString()}
+            sub="만료"
+            color="$expired"
+            onPress={() => onStatusChange("BLACK")}
+            opacity={activeStatus && activeStatus !== "BLACK" ? 0.3 : 1}
+          />
+        </XStack>
+        <Separator vertical height={ms(46)} opacity={1} />
+        <XStack f={1} minWidth={0} jc="center">
+          <StatusItem
+            icon={<AlertCircle size={s(13)} color="$warning" />}
+            label="임박"
+            count={counts.RED.toString()}
+            sub="10일 이내"
+            color="$warning"
+            onPress={() => onStatusChange("RED")}
+            opacity={activeStatus && activeStatus !== "RED" ? 0.3 : 1}
+          />
+        </XStack>
+        <Separator vertical height={ms(46)} opacity={1} />
+        <XStack f={1} minWidth={0} jc="center">
+          <StatusItem
+            icon={<AlertTriangle size={s(13)} color="$alert" />}
+            label="주의"
+            count={counts.YELLOW.toString()}
+            sub="20일 이내"
+            color="$alert"
+            onPress={() => onStatusChange("YELLOW")}
+            opacity={activeStatus && activeStatus !== "YELLOW" ? 0.3 : 1}
+          />
+        </XStack>
+        <Separator vertical height={ms(46)} opacity={1} />
+        <XStack f={1} minWidth={0} jc="center">
+          <StatusItem
+            icon={<CheckCircle size={s(13)} color="$success" />}
+            label="양호"
+            count={counts.GREEN.toString()}
+            sub="20일 이상"
+            color="$success"
+            onPress={() => onStatusChange("GREEN")}
+            opacity={activeStatus && activeStatus !== "GREEN" ? 0.3 : 1}
+          />
+        </XStack>
       </XStack>
     </Card>
   );

--- a/src/features/home/components/Expiry/Expiry.tsx
+++ b/src/features/home/components/Expiry/Expiry.tsx
@@ -19,7 +19,7 @@ export function Expiry({ activeStatus, onStatusChange, counts }: ExpiryProps) {
       p={rv({ sm: "$2", md: "$3", lg: "$3" })}
       mx="$4"
     >
-      <XStack ai="stretch" jc="space-between">
+      <XStack ai="center" jc="space-between">
         <XStack f={1} minWidth={0} jc="center">
           <StatusItem
             icon={<XCircle size={s(13)} color="$expired" />}
@@ -31,7 +31,15 @@ export function Expiry({ activeStatus, onStatusChange, counts }: ExpiryProps) {
             opacity={activeStatus && activeStatus !== "BLACK" ? 0.3 : 1}
           />
         </XStack>
-        <Separator vertical height={ms(46)} opacity={1} />
+        <Separator
+          vertical
+          alignSelf="center"
+          height={rv({ sm: ms(40), md: ms(46), lg: ms(46) })}
+          opacity={0.6}
+          f={0}
+          flexGrow={0}
+          flexShrink={0}
+        />
         <XStack f={1} minWidth={0} jc="center">
           <StatusItem
             icon={<AlertCircle size={s(13)} color="$warning" />}
@@ -43,7 +51,15 @@ export function Expiry({ activeStatus, onStatusChange, counts }: ExpiryProps) {
             opacity={activeStatus && activeStatus !== "RED" ? 0.3 : 1}
           />
         </XStack>
-        <Separator vertical height={ms(46)} opacity={1} />
+        <Separator
+          vertical
+          alignSelf="center"
+          height={rv({ sm: ms(40), md: ms(46), lg: ms(46) })}
+          opacity={0.6}
+          f={0}
+          flexGrow={0}
+          flexShrink={0}
+        />
         <XStack f={1} minWidth={0} jc="center">
           <StatusItem
             icon={<AlertTriangle size={s(13)} color="$alert" />}
@@ -55,7 +71,15 @@ export function Expiry({ activeStatus, onStatusChange, counts }: ExpiryProps) {
             opacity={activeStatus && activeStatus !== "YELLOW" ? 0.3 : 1}
           />
         </XStack>
-        <Separator vertical height={ms(46)} opacity={1} />
+        <Separator
+          vertical
+          alignSelf="center"
+          height={rv({ sm: ms(40), md: ms(46), lg: ms(46) })}
+          opacity={0.6}
+          f={0}
+          flexGrow={0}
+          flexShrink={0}
+        />
         <XStack f={1} minWidth={0} jc="center">
           <StatusItem
             icon={<CheckCircle size={s(13)} color="$success" />}

--- a/src/features/home/components/Expiry/StatusItem.tsx
+++ b/src/features/home/components/Expiry/StatusItem.tsx
@@ -1,3 +1,4 @@
+import { fs, getDeviceSize, rv } from "@/shared/constants/layout";
 import { Heading, Text, XStack, YStack } from "tamagui";
 import { StatusItemProps } from "../../types";
 
@@ -10,24 +11,60 @@ export function StatusItem({
   onPress,
   opacity,
 }: StatusItemProps) {
+  const isSm = getDeviceSize() === "sm";
   return (
     <YStack
       ai="center"
-      gap="$1"
+      gap={rv({ sm: fs(1), md: fs(2), lg: fs(2) })}
       onPress={onPress}
       opacity={opacity}
       pressStyle={{ opacity: 0.5 }}
+      flexShrink={1}
+      minWidth={0}
     >
-      <XStack ai="center" gap="$1">
-        {icon}
-        <Heading color={color} fontWeight="700" fontSize="$4">
-          {label}
-        </Heading>
-      </XStack>
-      <Text fontSize="$5" fontWeight="700" py="$1">
+      {isSm ? (
+        <YStack ai="center" gap={fs(1)} minWidth={0}>
+          {icon}
+          <Heading
+            color={color}
+            fontWeight="700"
+            fontSize={fs(10)}
+            fontFamily="$baemin"
+            numberOfLines={1}
+            textAlign="center"
+          >
+            {label}
+          </Heading>
+        </YStack>
+      ) : (
+        <XStack ai="center" gap="$1">
+          {icon}
+          <Heading
+            color={color}
+            fontWeight="700"
+            fontSize={rv({ sm: fs(10), md: fs(14), lg: fs(14) })}
+            fontFamily="$baemin"
+            numberOfLines={1}
+          >
+            {label}
+          </Heading>
+        </XStack>
+      )}
+      <Text
+        fontSize={rv({ sm: fs(12), md: fs(16), lg: fs(16) })}
+        fontWeight="800"
+        py="$1"
+        fontFamily="$baemin"
+      >
         {count}
       </Text>
-      <Text fontFamily="$baemin" fontSize={10} fontWeight="400" color="$gray9">
+      <Text
+        fontFamily="$baemin"
+        fontSize={rv({ sm: fs(9), md: fs(10), lg: fs(10) })}
+        fontWeight="400"
+        color="$gray9"
+        numberOfLines={1}
+      >
         {sub}
       </Text>
     </YStack>

--- a/src/features/home/components/Expiry/StatusItem.tsx
+++ b/src/features/home/components/Expiry/StatusItem.tsx
@@ -51,9 +51,9 @@ export function StatusItem({
         </XStack>
       )}
       <Text
-        fontSize={rv({ sm: fs(12), md: fs(16), lg: fs(16) })}
+        fontSize={rv({ sm: fs(13), md: fs(16), lg: fs(16) })}
         fontWeight="800"
-        py="$1"
+        py={rv({ sm: 0, md: 4, lg: 4 })}
         fontFamily="$baemin"
       >
         {count}

--- a/src/features/home/components/FoodListItem/FoodListItem.tsx
+++ b/src/features/home/components/FoodListItem/FoodListItem.tsx
@@ -86,7 +86,7 @@ export function FoodListItem({ item, onPress }: FoodListItemProps) {
 
         <YStack ai="flex-end" gap="$1">
           <View
-            width={rv({ sm: ms(38), md: ms(42), lg: ms(42) })}
+            minWidth={rv({ sm: ms(38), md: ms(42), lg: ms(42) })}
             py="$1"
             br="$2"
             bg={`${statusBgColor}`}

--- a/src/features/home/components/FoodListItem/FoodListItem.tsx
+++ b/src/features/home/components/FoodListItem/FoodListItem.tsx
@@ -7,6 +7,7 @@ import { getUnitLabel } from "@/shared/utils/food";
 import { Card, Heading, Image, Text, View, XStack, YStack } from "tamagui";
 import { getDefaultFoodCategoryImage } from "../../../../shared/utils/getDefaultFoodCategoryImage";
 import { FoodListItemProps } from "../../types";
+import { fs, ms, rv, s } from "@/shared/constants/layout";
 
 export function FoodListItem({ item, onPress }: FoodListItemProps) {
   const hasCustomImage = !!item.imageURL;
@@ -23,26 +24,30 @@ export function FoodListItem({ item, onPress }: FoodListItemProps) {
       bordered
       backgroundColor="$surface"
       borderRadius="$4"
-      mb="$4"
-      mx="$4"
+      mb={rv({ sm: "$3", md: "$4", lg: "$4" })}
+      mx={rv({ sm: "$3", md: "$4", lg: "$4" })}
       overflow="hidden"
       onPress={onPress}
       pressStyle={{ opacity: 0.85 }}
     >
-      <XStack p="$4" ai="center" gap="$4">
+      <XStack
+        p={rv({ sm: "$3", md: "$4", lg: "$4" })}
+        ai="center"
+        gap={rv({ sm: "$3", md: "$4", lg: "$4" })}
+      >
         <View
           position="absolute"
           left={0}
           top={0}
           bottom={0}
-          width={6}
+          width={s(6)}
           backgroundColor={statusColor}
         />
 
         <View
           ml="$2"
-          w={54}
-          h={54}
+          w={rv({ sm: ms(44), md: ms(50), lg: ms(50) })}
+          h={rv({ sm: ms(44), md: ms(50), lg: ms(50) })}
           br="$3"
           bg="$iconThumbnailBackground"
           bw={1}
@@ -70,22 +75,32 @@ export function FoodListItem({ item, onPress }: FoodListItemProps) {
         </View>
 
         <YStack f={1} gap="$1">
-          <Heading fontSize="$4" fontWeight="700">
+          <Heading fontSize={rv({ sm: fs(15), md: fs(16), lg: fs(16) })} fontWeight="700">
             {item.name}
           </Heading>
           <Text
-            fontSize="$3"
+            fontSize={rv({ sm: fs(12), md: fs(13), lg: fs(13) })}
             color="$gray10"
           >{`${item.quantity.amount} ${unitLabel} • ${item.categoryName}`}</Text>
         </YStack>
 
         <YStack ai="flex-end" gap="$1">
-          <View width={45} py="$1" br="$2" bg={`${statusBgColor}`} ai="center">
-            <Text color={statusColor} fontWeight="800" fontSize="$3">
+          <View
+            width={rv({ sm: ms(38), md: ms(42), lg: ms(42) })}
+            py="$1"
+            br="$2"
+            bg={`${statusBgColor}`}
+            ai="center"
+          >
+            <Text
+              color={statusColor}
+              fontWeight="800"
+              fontSize={rv({ sm: fs(11), md: fs(12), lg: fs(12) })}
+            >
               {isExpired ? "만료" : `D-${daysLeft}`}
             </Text>
           </View>
-          <Text fontSize={10} color="$gray9">
+          <Text fontSize={rv({ sm: fs(10), md: fs(11), lg: fs(11) })} color="$gray9">
             {isExpired ? "기한 만료" : expiryLabel}
           </Text>
         </YStack>

--- a/src/features/home/components/FoodListItem/SwipeableFoodListItem.tsx
+++ b/src/features/home/components/FoodListItem/SwipeableFoodListItem.tsx
@@ -4,6 +4,7 @@ import ReanimatedSwipeable from "react-native-gesture-handler/ReanimatedSwipeabl
 import { Button, Text, View, YStack } from "tamagui";
 import { SwipeableFoodListItemProps } from "../../types";
 import { FoodListItem } from "./FoodListItem";
+import { fs, ms, s } from "@/shared/constants/layout";
 
 export function SwipeableFoodListItem({
   item,
@@ -15,7 +16,7 @@ export function SwipeableFoodListItem({
 
   const renderRightActions = () => {
     return (
-      <View width={80} mr="$4" mb="$4" jc="center">
+      <View width={ms(72)} mr="$4" mb="$4" jc="center">
         <Button
           f={1}
           bg="$warning"
@@ -30,8 +31,8 @@ export function SwipeableFoodListItem({
           pressStyle={{ opacity: 0.7 }}
         >
           <YStack gap="$1" ai="center" jc="center">
-            <Trash2 size="$2" color="$white" />
-            <Text color="$white" fontSize={11} fontWeight="700">
+            <Trash2 size={s(18)} color="$white" />
+            <Text color="$white" fontSize={fs(11)} fontWeight="700">
               삭제
             </Text>
           </YStack>

--- a/src/features/home/components/FridgeTabScroll.tsx
+++ b/src/features/home/components/FridgeTabScroll.tsx
@@ -1,3 +1,4 @@
+import { ms, rv } from "@/shared/constants/layout";
 import { Plus } from "@tamagui/lucide-icons";
 import { Button, ScrollView, Text, XStack } from "tamagui";
 import { FridgeTabScrollProps } from "../types";
@@ -13,22 +14,25 @@ export function FridgeTabScroll({
     <ScrollView
       horizontal
       showsHorizontalScrollIndicator={false}
-      contentContainerStyle={{ paddingHorizontal: 16 }}
+      contentContainerStyle={{
+        paddingHorizontal: rv({ sm: ms(8), md: ms(12), lg: ms(12) }),
+      }}
     >
       <XStack gap="$2" ai="center" backgroundColor="$background">
         <Button
           onPress={onSelectAll}
-          bg={isAllSelected ? "$secondary" : "$surface"}
-          size="$4"
+          bg={isAllSelected ? "$primary" : "$surface"}
+          size={rv({ sm: "$3", md: "$4", lg: "$4" })}
           br="$4"
-          px="$5"
+          px={rv({ sm: "$4", md: "$5", lg: "$5" })}
+          h={rv({ sm: ms(32), md: ms(36), lg: ms(36) })}
           fontSize="$2"
           hoverStyle={{ scale: 0.95 }}
           pressStyle={{ scale: 0.9 }}
         >
           <Text
             fontFamily="$baemin"
-            fontSize="$3"
+            fontSize={rv({ sm: "$2", md: "$3", lg: "$3" })}
             color={isAllSelected ? "white" : "$gray"}
             fontWeight={isAllSelected ? "700" : "400"}
           >
@@ -42,17 +46,18 @@ export function FridgeTabScroll({
             <Button
               key={fridge.id}
               onPress={() => onSelect(fridge)}
-              bg={isActive ? "$secondary" : "$surface"}
-              size="$4"
+              bg={isActive ? "$primary" : "$surface"}
+              size={rv({ sm: "$3", md: "$4", lg: "$4" })}
               br="$4"
-              px="$5"
+              px={rv({ sm: "$4", md: "$5", lg: "$5" })}
+              h={rv({ sm: ms(32), md: ms(36), lg: ms(36) })}
               fontSize="$2"
               hoverStyle={{ scale: 0.95 }}
               pressStyle={{ scale: 0.9 }}
             >
               <Text
                 fontFamily="$baemin"
-                fontSize="$3"
+                fontSize={rv({ sm: "$2", md: "$3", lg: "$3" })}
                 color={isActive ? "white" : "$gray"}
                 fontWeight={isActive ? "700" : "400"}
               >
@@ -64,13 +69,14 @@ export function FridgeTabScroll({
 
         <Button
           icon={<Plus size="$1" color="$gray" />}
-          size="$4"
+          size={rv({ sm: "$3", md: "$4", lg: "$4" })}
           bg="$surface"
           br="$4"
-          px="$3"
+          px={rv({ sm: "$2", md: "$3", lg: "$3" })}
+          h={rv({ sm: ms(32), md: ms(36), lg: ms(36) })}
           chromeless
           fontFamily="$baemin"
-          fontSize="$3"
+          fontSize={rv({ sm: "$2", md: "$3", lg: "$3" })}
         >
           추가
         </Button>

--- a/src/features/home/components/FridgeTabScroll.tsx
+++ b/src/features/home/components/FridgeTabScroll.tsx
@@ -32,9 +32,10 @@ export function FridgeTabScroll({
         >
           <Text
             fontFamily="$baemin"
-            fontSize={rv({ sm: "$2", md: "$3", lg: "$3" })}
+            fontSize={rv({ sm: "$2", md: "$2", lg: "$3" })}
             color={isAllSelected ? "white" : "$gray"}
             fontWeight={isAllSelected ? "700" : "400"}
+            pt="$1"
           >
             전체
           </Text>
@@ -77,6 +78,7 @@ export function FridgeTabScroll({
           chromeless
           fontFamily="$baemin"
           fontSize={rv({ sm: "$2", md: "$3", lg: "$3" })}
+          color="$gray"
         >
           추가
         </Button>

--- a/src/features/home/components/HomeSkeleton.tsx
+++ b/src/features/home/components/HomeSkeleton.tsx
@@ -1,4 +1,5 @@
 import { View, XStack, YStack } from "tamagui";
+import { ms } from "@/shared/constants/layout";
 
 // 임시용 스켈레톤
 export function HomeSkeleton() {
@@ -6,19 +7,19 @@ export function HomeSkeleton() {
     <YStack gap="$5" px="$4" py="$2">
       <XStack gap="$2">
         {[1, 2, 3].map((i) => (
-          <View key={i} w={80} h={40} br="$4" bg="$gray3" />
+          <View key={i} w={ms(72)} h={ms(36)} br="$4" bg="$gray3" />
         ))}
       </XStack>
 
-      <View w="100%" h={120} br="$4" bg="$gray3" />
+      <View w="100%" h={ms(110)} br="$4" bg="$gray3" />
 
       <YStack gap="$3">
         {[1, 2, 3, 4].map((i) => (
           <XStack key={i} gap="$3" ai="center">
-            <View w={60} h={60} br="$2" bg="$gray3" />
+            <View w={ms(54)} h={ms(54)} br="$2" bg="$gray3" />
             <YStack f={1} gap="$2">
-              <View w="40%" h={15} bg="$gray3" />
-              <View w="70%" h={15} bg="$gray3" />
+              <View w="40%" h={ms(14)} bg="$gray3" />
+              <View w="70%" h={ms(14)} bg="$gray3" />
             </YStack>
           </XStack>
         ))}

--- a/src/features/home/components/SortFilter.tsx
+++ b/src/features/home/components/SortFilter.tsx
@@ -3,7 +3,7 @@ import { Modal, Pressable, ScrollView, StyleSheet } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AnimatePresence, Button, Text, View, XStack, YStack } from "tamagui";
 import { SortFilterProps, SortOption } from "../types";
-import { getBottomPaddingForSheet } from "@/shared/constants/layout";
+import { fs, getBottomPaddingForSheet, ms, s } from "@/shared/constants/layout";
 
 const SORT_OPTIONS: { label: string; value: SortOption }[] = [
   { label: "유통기한 임박순", value: "EXPIRY_ASC" },
@@ -58,16 +58,22 @@ export function SortFilter({
               y={0}
               opacity={1}
             >
-              <View w={56} h={6} bg="$gray4" br="$4" alignSelf="center" />
+              <View
+                w={s(56)}
+                h={s(6)}
+                bg="$gray4"
+                br="$4"
+                alignSelf="center"
+              />
 
               <XStack ai="center" jc="space-between">
-                <Text fontSize="$5" fontWeight="700" fontFamily="$baemin">
+                <Text fontSize={fs(16)} fontWeight="700" fontFamily="$baemin">
                   정렬 및 필터
                 </Text>
               </XStack>
 
               <YStack gap="$3">
-                <Text fontSize="$4" fontWeight="700" fontFamily="$heading">
+                <Text fontSize={fs(14)} fontWeight="700" fontFamily="$heading">
                   정렬 기준
                 </Text>
 
@@ -76,7 +82,7 @@ export function SortFilter({
                   return (
                     <Button
                       key={option.value}
-                      h={62}
+                      h={ms(52)}
                       bg="$surface"
                       boc="$gray3"
                       bw={1}
@@ -86,7 +92,7 @@ export function SortFilter({
                     >
                       <XStack f={1} ai="center" jc="space-between" px="$1">
                         <Text
-                          fontSize="$4"
+                          fontSize={fs(14)}
                           fontWeight="700"
                           color="$mainText"
                           fontFamily="$baemin"
@@ -95,16 +101,16 @@ export function SortFilter({
                         </Text>
 
                         <View
-                          w={34}
-                          h={34}
+                          w={s(30)}
+                          h={s(30)}
                           br={999}
-                          bw={4}
+                          bw={s(3)}
                           boc={isActive ? "$primary" : "$gray3"}
                           ai="center"
                           jc="center"
                         >
                           {isActive && (
-                            <View w={14} h={14} br={999} bg="$primary" />
+                            <View w={s(12)} h={s(12)} br={999} bg="$primary" />
                           )}
                         </View>
                       </XStack>
@@ -114,7 +120,7 @@ export function SortFilter({
               </YStack>
 
               <YStack gap="$3">
-                <Text fontSize="$4" fontWeight="700" fontFamily="$heading">
+                <Text fontSize={fs(14)} fontWeight="700" fontFamily="$heading">
                   카테고리
                 </Text>
 
@@ -131,10 +137,11 @@ export function SortFilter({
                           size="$4"
                           onPress={() => setDraftCategory(category)}
                           pressStyle={{ scale: 0.97 }}
+                          h={ms(40)}
                         >
                           <Text
                             fontFamily="$baemin"
-                            fontSize="$3"
+                            fontSize={fs(13)}
                             fontWeight="700"
                             color="$mainText"
                           >
@@ -148,7 +155,7 @@ export function SortFilter({
               </YStack>
 
               <Button
-                h={64}
+                h={ms(52)}
                 br="$6"
                 bg="$primary"
                 mt="$2"
@@ -161,7 +168,7 @@ export function SortFilter({
                 }}
                 pressStyle={{ scale: 0.98 }}
               >
-                <Text fontSize="$5" fontWeight="700" fontFamily="$baemin">
+                <Text fontSize={fs(15)} fontWeight="700" fontFamily="$baemin">
                   적용하기
                 </Text>
               </Button>

--- a/src/features/home/screens/HomeScreen.tsx
+++ b/src/features/home/screens/HomeScreen.tsx
@@ -21,6 +21,7 @@ import { useAllFoodStatusQuery } from "../hooks/queries/useAllFoodStatusQuery";
 import { useFridgeFoodStatusQuery } from "../hooks/queries/useFridgeFoodStatusQuery";
 import { useFridgeQuery } from "../hooks/queries/useFridgeQuery";
 import { FoodStatus, SortOption } from "../types";
+import { fs, ms } from "@/shared/constants/layout";
 
 interface DeleteTarget {
   // foodName은 삭제 확인 모달에 표시할지 말지 고민
@@ -184,7 +185,7 @@ export function HomeScreen() {
 
           <XStack jc="flex-end" px="$4" py="$2">
             <Text
-              fontSize={12}
+              fontSize={fs(12)}
               color="$gray"
               onPress={() => setIsFilterOpen(true)}
               pressStyle={{ opacity: 0.5 }}
@@ -235,7 +236,7 @@ export function HomeScreen() {
           )}
           keyExtractor={(item) => item.id.toString()}
           //@ts-ignore
-          contentContainerStyle={{ paddingBottom: 40 }}
+          contentContainerStyle={{ paddingBottom: ms(40) }}
           onEndReached={() => {
             if (!isAllFridgeTab && hasMoreFridgeFood) {
               fetchNextFridgePage();
@@ -244,7 +245,9 @@ export function HomeScreen() {
           onEndReachedThreshold={0.5}
           ListEmptyComponent={
             <YStack ai="center" jc="center" py="$10">
-              <Text color="$gray">해당 카테고리에 음식이 없습니다.</Text>
+              <Text color="$gray" fontSize={fs(14)}>
+                해당 카테고리에 음식이 없습니다.
+              </Text>
             </YStack>
           }
         />

--- a/src/features/notification/components/DayButton.tsx
+++ b/src/features/notification/components/DayButton.tsx
@@ -2,20 +2,27 @@ import { Check } from "@tamagui/lucide-icons";
 import React from "react";
 import { Button, Text } from "tamagui";
 import { DayButtonProps } from "../types";
+import { fs, ms, s } from "@/shared/constants/layout";
 
 export const DayButton = ({ day, active, onPress }: DayButtonProps) => (
   <Button
     size="$3"
     br="$2"
-    h={32}
+    h={ms(30)}
     paddingHorizontal="$5"
     backgroundColor={active ? "$primary" : "$gray3"}
     onPress={onPress}
     pressStyle={{ scale: 0.95 }}
-    icon={active ? <Check size={16} color="$white" strokeWidth={2} /> : null}
+    icon={
+      active ? <Check size={s(15)} color="$white" strokeWidth={2} /> : null
+    }
     animation="quick"
   >
-    <Text color={active ? "$white" : "$mainText"} fontWeight="700">
+    <Text
+      color={active ? "$white" : "$mainText"}
+      fontWeight="700"
+      fontSize={fs(13)}
+    >
       {day}일 전
     </Text>
   </Button>

--- a/src/features/notification/components/DayButton.tsx
+++ b/src/features/notification/components/DayButton.tsx
@@ -1,21 +1,19 @@
+import { fs, ms, s } from "@/shared/constants/layout";
 import { Check } from "@tamagui/lucide-icons";
 import React from "react";
 import { Button, Text } from "tamagui";
 import { DayButtonProps } from "../types";
-import { fs, ms, s } from "@/shared/constants/layout";
 
 export const DayButton = ({ day, active, onPress }: DayButtonProps) => (
   <Button
     size="$3"
     br="$2"
-    h={ms(30)}
+    h={ms(36)}
     paddingHorizontal="$5"
     backgroundColor={active ? "$primary" : "$gray3"}
     onPress={onPress}
     pressStyle={{ scale: 0.95 }}
-    icon={
-      active ? <Check size={s(15)} color="$white" strokeWidth={2} /> : null
-    }
+    icon={active ? <Check size={s(15)} color="$white" strokeWidth={2} /> : null}
     animation="quick"
   >
     <Text

--- a/src/features/notification/components/NotificationItem.tsx
+++ b/src/features/notification/components/NotificationItem.tsx
@@ -6,6 +6,7 @@ import { Pressable } from "react-native";
 import { Circle, Text, XStack, YStack } from "tamagui";
 import { useNotificationStore } from "../stores/useNotificationStore";
 import type { NotificationItemProps } from "../types";
+import { fs, ms, s } from "@/shared/constants/layout";
 
 // 알림 유형에 따른 스타일 (현재는 유통기한)
 const NOTIFICATION_CONFIG = {
@@ -36,14 +37,14 @@ export const NotificationItem = ({ item }: { item: NotificationItemProps }) => {
         ai="flex-start"
         opacity={item.isRead ? 0.3 : 1}
       >
-        <Circle size={40} backgroundColor={NOTIFICATION_CONFIG.bg}>
-          <Icon size={20} color={NOTIFICATION_CONFIG.color} />
+        <Circle size={ms(36)} backgroundColor={NOTIFICATION_CONFIG.bg}>
+          <Icon size={s(18)} color={NOTIFICATION_CONFIG.color} />
         </Circle>
 
         <YStack f={1} gap="$1">
           <XStack jc="space-between" ai="center">
             <Text
-              fontSize={12}
+              fontSize={fs(12)}
               color={NOTIFICATION_CONFIG.color}
               fontWeight="700"
             >
@@ -53,7 +54,9 @@ export const NotificationItem = ({ item }: { item: NotificationItemProps }) => {
               <Text fontSize="$3" color="$gray9">
                 {formatNotificationTime(item.createdAt)}
               </Text>
-              {!item.isRead && <Circle size={6} backgroundColor="$red10" />}
+              {!item.isRead && (
+                <Circle size={s(6)} backgroundColor="$red10" />
+              )}
             </XStack>
           </XStack>
 

--- a/src/features/notification/components/SettingRow.tsx
+++ b/src/features/notification/components/SettingRow.tsx
@@ -1,7 +1,7 @@
+import { ms } from "@/shared/constants/layout";
 import React from "react";
 import { Switch, Text, XStack, YStack } from "tamagui";
 import { SettingRowProps } from "../types";
-import { ms } from "@/shared/constants/layout";
 
 export const SettingRow = ({
   icon,
@@ -31,7 +31,7 @@ export const SettingRow = ({
       backgroundColor={checked ? "$primary" : "$gray4"}
       height={ms(28)}
       width={ms(46)}
-      p={ms(2)}
+      p={ms(1)}
     >
       <Switch.Thumb size="$4" animation="quick" />
     </Switch>

--- a/src/features/notification/components/SettingRow.tsx
+++ b/src/features/notification/components/SettingRow.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Switch, Text, XStack, YStack } from "tamagui";
 import { SettingRowProps } from "../types";
+import { ms } from "@/shared/constants/layout";
 
 export const SettingRow = ({
   icon,
@@ -28,9 +29,9 @@ export const SettingRow = ({
       checked={checked}
       onCheckedChange={onCheckedChange}
       backgroundColor={checked ? "$primary" : "$gray4"}
-      height={30}
-      width={50}
-      p={2}
+      height={ms(28)}
+      width={ms(46)}
+      p={ms(2)}
     >
       <Switch.Thumb size="$4" animation="quick" />
     </Switch>

--- a/src/features/onboarding/components/OnboardingItem.tsx
+++ b/src/features/onboarding/components/OnboardingItem.tsx
@@ -2,15 +2,17 @@ import { Image } from "expo-image";
 import { useWindowDimensions } from "react-native";
 import { Paragraph, Text, View, YStack } from "tamagui";
 import { OnboardingItemProps } from "../types";
+import { fs, ms } from "@/shared/constants/layout";
 
 export function OnboardingItem({ item, isDark }: OnboardingItemProps) {
   const { width: screenWidth } = useWindowDimensions();
+  const imageHeight = ms(280);
   return (
     <View w={screenWidth} px="$6">
-      <YStack pt="$6" ai="center">
+      <YStack pt="$5" ai="center">
         <View
           w="100%"
-          h={360}
+          h={imageHeight}
           br="$6"
           bg="#E9E8EB"
           overflow="hidden"
@@ -23,14 +25,14 @@ export function OnboardingItem({ item, isDark }: OnboardingItemProps) {
             contentFit="cover"
           />
         </View>
-        <YStack mt="$6" ai="center">
+        <YStack mt="$5" ai="center">
           <Text
             fontFamily="$heading"
-            fontSize={26}
+            fontSize={fs(20)}
             fontWeight="800"
             color={isDark ? "#FFFFFF" : "#0B1110"}
             textAlign="center"
-            lineHeight={34}
+            lineHeight={ms(28)}
           >
             {item.title}
           </Text>
@@ -40,7 +42,7 @@ export function OnboardingItem({ item, isDark }: OnboardingItemProps) {
             fontSize="$3"
             color={isDark ? "#B6C2BF" : "#667085"}
             textAlign="center"
-            lineHeight={22}
+            lineHeight={ms(18)}
           >
             {item.description}
           </Paragraph>

--- a/src/features/onboarding/screens/OnboardingScreen.tsx
+++ b/src/features/onboarding/screens/OnboardingScreen.tsx
@@ -6,6 +6,7 @@ import { Button, Circle, Text, XStack, YStack } from "tamagui";
 import { OnboardingItem } from "../components/OnboardingItem";
 import { SLIDES } from "../constants/slides";
 import { useOnboarding } from "../hooks/useOnboarding";
+import { fs, ms, s } from "@/shared/constants/layout";
 
 export function OnboardingScreen() {
   const { theme, toggleTheme } = useThemeStore();
@@ -26,7 +27,7 @@ export function OnboardingScreen() {
       <YStack f={1}>
         <XStack px="$6" pt="$2" jc="flex-end">
           <Button unstyled onPress={toggleTheme}>
-            <Moon size={20} color={isDark ? "#FFFFFF" : "#0B1110"} />
+            <Moon size={s(18)} color={isDark ? "#FFFFFF" : "#0B1110"} />
           </Button>
         </XStack>
 
@@ -48,7 +49,7 @@ export function OnboardingScreen() {
             {SLIDES.map((_, i) => (
               <Circle
                 key={i}
-                size={8}
+                size={s(7)}
                 bg={i === index ? "$primary" : "$gray10"}
                 opacity={i === index ? 1 : 0.6}
               />
@@ -58,12 +59,14 @@ export function OnboardingScreen() {
           <Button
             bc="$primary"
             color="$white"
-            h={56}
+            h={ms(48)}
             br="$4"
             fontWeight="800"
             onPress={isLastSlide ? completeAndGoNext : handleNext}
           >
-            {isLastSlide ? "Fridgely 시작하기" : "다음"}
+            <Text fontFamily="$baemin" fontWeight="800" fontSize={fs(15)} color="$white">
+              {isLastSlide ? "Fridgely 시작하기" : "다음"}
+            </Text>
           </Button>
 
           <Button unstyled onPress={completeAndGoNext} alignSelf="center">
@@ -71,6 +74,7 @@ export function OnboardingScreen() {
               fontFamily="$baemin"
               color={isDark ? "#B6C2BF" : "#667085"}
               textDecorationLine="underline"
+              fontSize={fs(13)}
             >
               건너뛰기
             </Text>

--- a/src/features/profile/components/Menu.tsx
+++ b/src/features/profile/components/Menu.tsx
@@ -1,4 +1,4 @@
-import { fs, rv, s } from "@/shared/constants/layout";
+import { fs, ms, rv, s } from "@/shared/constants/layout";
 import { ChevronRight } from "@tamagui/lucide-icons";
 import React from "react";
 import { Separator, Text, View, XStack } from "tamagui";
@@ -23,7 +23,8 @@ export function Menu({
   return (
     <>
       <XStack
-        padding={rv({ sm: "$1", md: "$4", lg: "$4" })}
+        minHeight={ms(44)}
+        padding={rv({ sm: "$3", md: "$4", lg: "$4" })}
         alignItems="center"
         justifyContent="space-between"
         pressStyle={{ backgroundColor: "$gray2" }}

--- a/src/features/profile/components/Menu.tsx
+++ b/src/features/profile/components/Menu.tsx
@@ -1,3 +1,4 @@
+import { fs, rv, s } from "@/shared/constants/layout";
 import { ChevronRight } from "@tamagui/lucide-icons";
 import React from "react";
 import { Separator, Text, View, XStack } from "tamagui";
@@ -15,33 +16,40 @@ export function Menu({
   const clonedIcon = React.isValidElement(icon)
     ? React.cloneElement(icon as React.ReactElement<any>, {
         color: iconColor,
-        size: 20,
+        size: rv({ sm: s(17), md: s(18), lg: s(18) }),
       })
     : icon;
 
   return (
     <>
       <XStack
-        padding="$4"
+        padding={rv({ sm: "$1", md: "$4", lg: "$4" })}
         alignItems="center"
         justifyContent="space-between"
         pressStyle={{ backgroundColor: "$gray2" }}
         onPress={onPress}
       >
-        <XStack alignItems="center" gap="$3">
-          <View p="$2" borderRadius="$3" backgroundColor={backgroundColor}>
+        <XStack alignItems="center" gap={rv({ sm: "$3", md: "$3", lg: "$3" })}>
+          <View
+            p={rv({ sm: "$2", md: "$2", lg: "$2" })}
+            borderRadius="$3"
+            backgroundColor={backgroundColor}
+          >
             {clonedIcon}
           </View>
           <Text
             fontFamily="$baemin"
-            fontSize="$4"
+            fontSize={rv({ sm: fs(14), md: fs(15), lg: fs(15) })}
             fontWeight="400"
             color={titleColor}
           >
             {title}
           </Text>
         </XStack>
-        <ChevronRight size={20} color={titleColor} />
+        <ChevronRight
+          size={rv({ sm: s(17), md: s(18), lg: s(18) })}
+          color={titleColor}
+        />
       </XStack>
       {!isLast && <Separator marginLeft="$12" />}
     </>

--- a/src/features/profile/screens/ProfileScreen.tsx
+++ b/src/features/profile/screens/ProfileScreen.tsx
@@ -1,5 +1,10 @@
 import { Header } from "@/shared/components/Header/Header";
-import { getBottomPaddingForSheet } from "@/shared/constants/layout";
+import {
+  fs,
+  getBottomPaddingForSheet,
+  ms,
+  rv,
+} from "@/shared/constants/layout";
 import { useThemeStore } from "@/shared/stores/useThemeStore";
 import {
   Bell,
@@ -151,20 +156,30 @@ export function ProfileScreen() {
 
       <ScrollView showsVerticalScrollIndicator={false}>
         <YStack
-          padding="$4"
-          gap="$6"
+          padding={rv({ sm: "$3", md: "$4", lg: "$4" })}
+          gap={rv({ sm: "$5", md: "$6", lg: "$6" })}
           style={{
-            paddingBottom: getBottomPaddingForSheet({ bottomInset: insets.bottom }),
+            paddingBottom: getBottomPaddingForSheet({
+              bottomInset: insets.bottom,
+            }),
           }}
         >
           {/* 프로필 */}
-          <YStack alignItems="center" gap="$2" marginTop="$4">
-            <Avatar circular size={100}>
+          <YStack
+            alignItems="center"
+            gap="$2"
+            marginTop={rv({ sm: "$3", md: "$4", lg: "$4" })}
+          >
+            <Avatar circular size={rv({ sm: ms(72), md: ms(86), lg: ms(86) })}>
               <Avatar.Image source={profileImageSource} />
               <Avatar.Fallback bc="$blue10" />
             </Avatar>
             <YStack alignItems="center">
-              <Heading size="$5" fontWeight="700">
+              <Heading
+                size="$5"
+                fontWeight="700"
+                fontSize={rv({ sm: fs(16), md: fs(18), lg: fs(18) })}
+              >
                 {nickname}님
               </Heading>
             </YStack>
@@ -178,14 +193,20 @@ export function ProfileScreen() {
               onPress={handleProfileImageUpdate}
               disabled={isUpdatingProfileImage}
             >
-              {isUpdatingProfileImage ? "업로드 중..." : "프로필 수정"}
+              <Text
+                fontFamily="$baemin"
+                fontSize={rv({ sm: fs(12), md: fs(13), lg: fs(13) })}
+                fontWeight="600"
+              >
+                {isUpdatingProfileImage ? "업로드 중..." : "프로필 수정"}
+              </Text>
             </Button>
           </YStack>
 
           {/* 식품 개수 */}
           <XStack gap="$3" justifyContent="center">
             <Card
-              p="$4"
+              p={rv({ sm: "$3", md: "$4", lg: "$4" })}
               borderRadius="$4"
               borderWidth={1}
               borderColor="$gray3"
@@ -193,10 +214,19 @@ export function ProfileScreen() {
               f={1}
             >
               <YStack gap="$2">
-                <Text color="$gray" fontSize="$4">
+                <Text
+                  color="$gray"
+                  fontSize={rv({ sm: fs(11), md: fs(13), lg: fs(13) })}
+                  fontFamily="$baemin"
+                >
                   등록한 식품
                 </Text>
-                <Heading color="$mainText" size="$5" fontWeight="700">
+                <Heading
+                  color="$mainText"
+                  size="$5"
+                  fontWeight="700"
+                  fontSize={rv({ sm: fs(15), md: fs(18), lg: fs(18) })}
+                >
                   {registeredFoodCount}개
                 </Heading>
               </YStack>
@@ -242,11 +272,21 @@ export function ProfileScreen() {
             />
           </YStack>
 
-          <YStack alignItems="center" gap="$1" marginTop="$4">
-            <Text color="$gray10" fontSize="$3">
+          <YStack
+            alignItems="center"
+            gap="$1"
+            marginTop={rv({ sm: "$3", md: "$4", lg: "$4" })}
+          >
+            <Text
+              color="$gray10"
+              fontSize={rv({ sm: fs(12), md: fs(13), lg: fs(13) })}
+            >
               Fridgely App
             </Text>
-            <Text color="$gray10" fontSize="$3">
+            <Text
+              color="$gray10"
+              fontSize={rv({ sm: fs(12), md: fs(13), lg: fs(13) })}
+            >
               버전 1.0.0
             </Text>
           </YStack>

--- a/src/features/search/components/SearchResultItem.tsx
+++ b/src/features/search/components/SearchResultItem.tsx
@@ -1,6 +1,7 @@
 import { FoodItem } from "@/shared/types/food";
 import { Image, Text, View, XStack, YStack } from "tamagui";
 import { getDefaultFoodCategoryImage } from "../../../shared/utils/getDefaultFoodCategoryImage";
+import { fs, ms } from "@/shared/constants/layout";
 interface Props {
   item: FoodItem;
   onPress?: () => void;
@@ -29,8 +30,8 @@ export function SearchResultItem({ item, onPress }: Props) {
       pressStyle={{ opacity: 0.8 }}
     >
       <View
-        w={50}
-        h={50}
+        w={ms(46)}
+        h={ms(46)}
         br="$4"
         backgroundColor="$iconThumbnailBackground"
         bw={1}
@@ -60,14 +61,14 @@ export function SearchResultItem({ item, onPress }: Props) {
 
       <YStack f={1} gap="$1">
         <Text
-          fontSize="$4"
+          fontSize={fs(15)}
           fontWeight="700"
           fontFamily="$heading"
           color="$mainText"
         >
           {item.name}
         </Text>
-        <Text fontSize={13} color="$gray10">
+        <Text fontSize={fs(12)} color="$gray10">
           {item.condition.storageType === "REFRIGERATION"
             ? "냉장고"
             : item.condition.storageType === "FROZEN"
@@ -83,11 +84,11 @@ export function SearchResultItem({ item, onPress }: Props) {
           br="$3"
           bc={statusColors[item.condition.foodStatus]}
         >
-          <Text fontSize={10} color="$white" fontWeight="bold">
+          <Text fontSize={fs(10)} color="$white" fontWeight="bold">
             {isExpired ? "만료" : `D-${item.condition.daysLeft}`}
           </Text>
         </View>
-        <Text fontSize={10} color="$gray10">
+        <Text fontSize={fs(10)} color="$gray10">
           {item.condition.expirationDate.split("T")[0]}
         </Text>
       </YStack>

--- a/src/shared/components/Header/Header.tsx
+++ b/src/shared/components/Header/Header.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Button, Heading, View, XStack } from "tamagui";
 import { HeaderProps } from "./Header.types";
+import { fs, ms, s } from "@/shared/constants/layout";
 export function Header({
   title = "Fridgely",
   showBackButton = false,
@@ -19,7 +20,7 @@ export function Header({
   return (
     <View backgroundColor="$background" style={{ paddingTop: insets.top }}>
       <XStack
-        height={60}
+        height={ms(56)}
         paddingHorizontal="$4"
         alignItems="center"
         justifyContent="center"
@@ -30,7 +31,7 @@ export function Header({
             <Button
               size="$2"
               chromeless
-              icon={<ChevronLeft size={24} color="$mainText" />}
+              icon={<ChevronLeft size={s(22)} color="$mainText" />}
               onPress={() => router.back()}
               paddingLeft={0}
             />
@@ -40,6 +41,7 @@ export function Header({
               fontWeight="700"
               color="$mainText"
               letterSpacing={-0.5}
+              fontSize={fs(20)}
             >
               {title}
             </Heading>
@@ -47,7 +49,7 @@ export function Header({
         </XStack>
 
         {showBackButton && (
-          <Heading size="$5" fontWeight="700" color="$mainText">
+          <Heading size="$5" fontWeight="700" color="$mainText" fontSize={fs(18)}>
             {title}
           </Heading>
         )}
@@ -60,14 +62,14 @@ export function Header({
               chromeless
               icon={
                 <View position="relative">
-                  <Bell size={24} color="$mainText" />
+                  <Bell size={s(22)} color="$mainText" />
                   {hasUnreadNotifications && (
                     <View
                       position="absolute"
-                      top={-2}
-                      right={-2}
-                      width={8}
-                      height={8}
+                      top={-s(2)}
+                      right={-s(2)}
+                      width={s(8)}
+                      height={s(8)}
                       borderRadius={100}
                       backgroundColor="$warning"
                     />

--- a/src/shared/components/OverlayMenu/MenuIcon.tsx
+++ b/src/shared/components/OverlayMenu/MenuIcon.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Dimensions } from "react-native";
 import { Circle, Text, YStack } from "tamagui";
 import { MenuIconProps } from "./MenuIcon.types";
+import { fs, ms, s } from "@/shared/constants/layout";
 
 const { width: SCREEN_WIDTH } = Dimensions.get("window");
 
@@ -13,7 +14,7 @@ export function MenuIcon({
   onPress,
   isDisabled,
 }: MenuIconProps) {
-  const ICON_SIZE = 60;
+  const ICON_SIZE = ms(52);
   const HALF_SIZE = ICON_SIZE / 2;
 
   //   삼각함수를 잉용하여 좌표 계산
@@ -24,13 +25,13 @@ export function MenuIcon({
   return (
     <YStack
       position="absolute"
-      bottom={60 + y}
+      bottom={ms(52) + y}
       //   화면 중앙ㅇ을 기준으로 x만큼 이동 후 아이콘 크기의 절반만큼 보정
       left={SCREEN_WIDTH / 2 + x - HALF_SIZE}
       ai="center"
-      width={ICON_SIZE + 30}
+      width={ICON_SIZE + ms(24)}
       //   width가 아이콘 크기보다 커서 중앙 정렬을 위해 marginLeft로 보정
-      style={{ marginLeft: -15 }}
+      style={{ marginLeft: -ms(12) }}
     >
       <Circle
         size={ICON_SIZE}
@@ -43,22 +44,27 @@ export function MenuIcon({
       >
         {React.cloneElement(icon as any, {
           color: "$primary",
-          size: ICON_SIZE * 0.5,
+          size: s(ICON_SIZE * 0.5),
         })}
       </Circle>
       <Text
         color="$white"
-        fontSize="$3"
+        fontSize={fs(12)}
         fontWeight="400"
         textAlign="center"
         textShadowColor="rgba(0,0,0,0.5)"
         textShadowRadius={4}
-        mt={3}
+        mt={ms(3)}
       >
         {label}
       </Text>
       {isDisabled && (
-        <Text color="$warning" position="absolute" bottom={-13} fontSize={12}>
+        <Text
+          color="$warning"
+          position="absolute"
+          bottom={-ms(13)}
+          fontSize={fs(12)}
+        >
           준비중
         </Text>
       )}

--- a/src/shared/constants/layout.ts
+++ b/src/shared/constants/layout.ts
@@ -1,4 +1,101 @@
-export const DEFAULT_BOTTOM_SPACING = 24;
+import { Dimensions, PixelRatio } from "react-native";
+
+// pixel7 기준으로 스케일 계산
+const BASE_WIDTH = 412;
+const BASE_HEIGHT = 915;
+
+function getWindow() {
+  return Dimensions.get("window");
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function getWidthScale() {
+  const { width } = getWindow();
+  return width / BASE_WIDTH;
+}
+
+function getHeightScale() {
+  const { height } = getWindow();
+  return height / BASE_HEIGHT;
+}
+
+/**
+ * 폭 기반 스케일.
+ * - spacing/icon/radius 같은 레이아웃 크기에 사용
+ * - 작은 폰에서는 줄고, 큰 폰에서는 거의 원본을 유지
+ */
+export function s(size: number) {
+  const scaled = size * getWidthScale();
+  const capped = clamp(scaled, size * 0.88, size * 1.02);
+  return PixelRatio.roundToNearestPixel(capped);
+}
+
+/**
+ * 높이(height) 기반 스케일.
+ * - 세로 길이에 민감해질 수 있으니 필요한 곳에만 제한적으로 사용
+ */
+export function vs(size: number) {
+  const scaled = size * getHeightScale();
+  const capped = clamp(scaled, size * 0.9, size * 1.03);
+  return PixelRatio.roundToNearestPixel(capped);
+}
+
+/**
+ * 완화 스케일(moderate scale).
+ * - 원본 값과 스케일 값을 섞어서 과한 변화 방지
+ * - factor는 보통 0.3~0.5 권장
+ */
+export function ms(size: number, factor = 0.4) {
+  const scaled = s(size);
+  return PixelRatio.roundToNearestPixel(size + (scaled - size) * factor);
+}
+
+/**
+ * 폰트 크기 정규화(font size normalize).
+ * - 작은 폰에서는 확실히 줄이되, OS 접근성 설정(fontScale)은 존중
+ * - 레이아웃 스케일과 분리해서 폰트 전용으로 사용
+ */
+export function fs(size: number, options?: { min?: number; max?: number }) {
+  const fontScale = PixelRatio.getFontScale?.() ?? 1;
+  const scaled = ms(size, 0.35) / fontScale;
+  const min = options?.min ?? size * 0.88;
+  const max = options?.max ?? size * 1.02;
+  return clamp(scaled, min, max);
+}
+
+export function lh(fontSize: number, lineHeightRatio = 1.35) {
+  return Math.round(fontSize * lineHeightRatio);
+}
+
+export type DeviceSize = "sm" | "md" | "lg";
+
+export function getDeviceSize(): DeviceSize {
+  const { width, height } = getWindow();
+  /**
+   * 폭이 360dp여도 기기마다 세로가 크게 달라서,
+   * 단순히 width만으로 sm/md를 나누면 실제 기기에서 깨질 수 있다.
+   *
+   * - Small Phone AVD(720x1280@320dpi) ≈ 360x640dp → sm
+   * - Galaxy A32(720x1600@~270dpi) ≈ 360x800dp → md로 취급
+   */
+  if (width <= 360 && height <= 720) return "sm";
+  if (width <= 410) return "md";
+  return "lg";
+}
+
+/**
+ * 반응형 값 선택 헬퍼(media-query 없이 사용).
+ * - `getDeviceSize()` 결과(sm/md/lg)에 따라 값을 선택한다.
+ */
+export function rv<T>(values: { sm: T; md: T; lg: T }) {
+  const size = getDeviceSize();
+  return values[size];
+}
+
+export const DEFAULT_BOTTOM_SPACING = ms(24);
 
 export function getBottomPaddingForSheet({
   bottomInset,
@@ -10,3 +107,18 @@ export function getBottomPaddingForSheet({
   return bottomInset + extraSpacing;
 }
 
+export const spacing = {
+  xs: ms(4),
+  sm: ms(8),
+  md: ms(12),
+  lg: ms(16),
+  xl: ms(20),
+  "2xl": ms(24),
+} as const;
+
+export const radius = {
+  sm: ms(8),
+  md: ms(12),
+  lg: ms(16),
+  xl: ms(20),
+} as const;

--- a/src/shared/constants/layout.ts
+++ b/src/shared/constants/layout.ts
@@ -55,15 +55,14 @@ export function ms(size: number, factor = 0.4) {
 
 /**
  * 폰트 크기 정규화(font size normalize).
- * - 작은 폰에서는 확실히 줄이되, OS 접근성 설정(fontScale)은 존중
+ * - 작은 폰에서는 확실히 줄이되, OS 접근성 설정(fontScale)은 React Native가 자동 반영하므로 여기서 나누지 않는다.
  * - 레이아웃 스케일과 분리해서 폰트 전용으로 사용
  */
 export function fs(size: number, options?: { min?: number; max?: number }) {
-  const fontScale = PixelRatio.getFontScale?.() ?? 1;
-  const scaled = ms(size, 0.35) / fontScale;
+  const scaled = ms(size, 0.35);
   const min = options?.min ?? size * 0.88;
   const max = options?.max ?? size * 1.02;
-  return clamp(scaled, min, max);
+  return PixelRatio.roundToNearestPixel(clamp(scaled, min, max));
 }
 
 export function lh(fontSize: number, lineHeightRatio = 1.35) {


### PR DESCRIPTION
## 작업 내용

- 전역 반응형 스케일 정책 도입: src/shared/constants/layout.ts에 s/vs/ms/fs/rv 추가 및 주석 정리
-  360dp 기기(Small Phone과 Galaxy A32)를 높이(dp)까지 고려해 sm/md 분리
- 모든 페이지 및 컴포넌트에 반응형 스케일 적용

## 연관 이슈

- #107


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 기기 크기별 반응형 레이아웃 지원 추가 — 폰트, 버튼, 입력 필드, 아이콘 등이 화면 크기에 맞춰 조정됩니다

* **Refactor**
  * 앱 전반의 스타일/레이아웃을 중앙화된 스케일링 체계로 전환하여 디자인 일관성 및 유지보수성 향상

* **Style**
  * 여러 화면과 컴포넌트의 타이포그래피·간격·아이콘 크기 조정으로 UI 균형감 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->