### PR TITLE
Fix: 알림 설정 변경 시 UI 반응 지연 개선

### DIFF
--- a/ReactotronConfig.js
+++ b/ReactotronConfig.js
@@ -2,12 +2,28 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import axios from "axios";
 import reactotronZustand from "reactotron-plugin-zustand";
 import Reactotron from "reactotron-react-native";
+import { NativeModules, Platform } from "react-native";
 import { useAuthStore } from "./src/features/auth/store/useAuthStore";
+
+const getReactotronHost = () => {
+  // Android 실기기 USB 연결은 `adb reverse tcp:9090 tcp:9090` 기준으로 localhost 사용
+  if (Platform.OS === "android") return "localhost";
+
+  // iOS(실기기/시뮬레이터)는 보통 같은 네트워크에서 PC IP로 붙어야 함.
+  // Metro 주소에서 호스트를 추출해 자동으로 맞춤.
+  const scriptURL = NativeModules.SourceCode?.scriptURL;
+  if (typeof scriptURL === "string") {
+    const match = scriptURL.match(/^https?:\/\/([^:/]+)(?::\d+)?\//);
+    if (match?.[1]) return match[1];
+  }
+
+  return "localhost";
+};
 
 Reactotron.setAsyncStorageHandler(AsyncStorage)
   .configure({
     name: "My Project",
-    host: "10.0.2.2",
+    host: getReactotronHost(),
   })
   .useReactNative({
     asyncStorage: true,

--- a/src/features/notification/__tests__/hooks/useNotificationSettings.test.tsx
+++ b/src/features/notification/__tests__/hooks/useNotificationSettings.test.tsx
@@ -1,4 +1,6 @@
 import { act, renderHook } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
 import { useUpdateNotificationSettingMutation } from "../../hooks/mutations/useUpdateNotificationSettingMutation";
 import { useNotificationSettingQuery } from "../../hooks/queries/useNotificationSettingQuery";
 import { useNotificationSettings } from "../../hooks/useNotificationSettings";
@@ -18,6 +20,22 @@ const mockedUseUpdateNotificationSettingMutation =
 
 describe("useNotificationSettings 테스트", () => {
   const mockMutate = jest.fn();
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    return function Wrapper({ children }: { children: React.ReactNode }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      );
+    };
+  };
 
   const mockSettings = {
     notificationTime: "09:00:00",
@@ -47,7 +65,9 @@ describe("useNotificationSettings 테스트", () => {
       isPending: true,
     });
 
-    const { result } = renderHook(() => useNotificationSettings());
+    const { result } = renderHook(() => useNotificationSettings(), {
+      wrapper: createWrapper(),
+    });
 
     expect(result.current.data).toEqual(mockSettings);
     expect(result.current.isUpdating).toBe(true);
@@ -55,7 +75,9 @@ describe("useNotificationSettings 테스트", () => {
   });
 
   it("하나만 변경하여 updateSettings 호출 시 기존 설정을 합쳐셔 mutate를 호출해야 한다", () => {
-    const { result } = renderHook(() => useNotificationSettings());
+    const { result } = renderHook(() => useNotificationSettings(), {
+      wrapper: createWrapper(),
+    });
 
     act(() => {
       result.current.updateSettings({ enabled: false });
@@ -76,7 +98,9 @@ describe("useNotificationSettings 테스트", () => {
       error: null,
     });
 
-    const { result } = renderHook(() => useNotificationSettings());
+    const { result } = renderHook(() => useNotificationSettings(), {
+      wrapper: createWrapper(),
+    });
 
     act(() => {
       result.current.updateSettings({ notificationTime: "10:30:00" });
@@ -87,7 +111,9 @@ describe("useNotificationSettings 테스트", () => {
   });
 
   it("여러 필드를 변경해도 빠진 값은 기존 설정으로 유지해서 mutate를 호출해야 한다", () => {
-    const { result } = renderHook(() => useNotificationSettings());
+    const { result } = renderHook(() => useNotificationSettings(), {
+      wrapper: createWrapper(),
+    });
 
     act(() => {
       result.current.updateSettings({

--- a/src/features/notification/components/DayButton.tsx
+++ b/src/features/notification/components/DayButton.tsx
@@ -1,27 +1,33 @@
 import { fs, ms, s } from "@/shared/constants/layout";
 import { Check } from "@tamagui/lucide-icons";
-import React from "react";
+import React, { memo } from "react";
 import { Button, Text } from "tamagui";
 import { DayButtonProps } from "../types";
 
-export const DayButton = ({ day, active, onPress }: DayButtonProps) => (
-  <Button
-    size="$3"
-    br="$2"
-    h={ms(36)}
-    paddingHorizontal="$5"
-    backgroundColor={active ? "$primary" : "$gray3"}
-    onPress={onPress}
-    pressStyle={{ scale: 0.95 }}
-    icon={active ? <Check size={s(15)} color="$white" strokeWidth={2} /> : null}
-    animation="quick"
-  >
-    <Text
-      color={active ? "$white" : "$mainText"}
-      fontWeight="700"
-      fontSize={fs(13)}
+export const DayButton = memo(
+  ({ day, active, onPress, disabled }: DayButtonProps) => (
+    <Button
+      size="$3"
+      br="$2"
+      h={ms(36)}
+      paddingHorizontal="$5"
+      backgroundColor={active ? "$primary" : "$gray3"}
+      onPress={onPress}
+      disabled={disabled}
+      pressStyle={{ scale: 0.95 }}
+      icon={
+        active ? <Check size={s(15)} color="$white" strokeWidth={2} /> : null
+      }
     >
-      {day}일 전
-    </Text>
-  </Button>
+      <Text
+        color={active ? "$white" : "$mainText"}
+        fontWeight="700"
+        fontSize={fs(13)}
+      >
+        {day}일 전
+      </Text>
+    </Button>
+  ),
 );
+
+DayButton.displayName = "DayButton";

--- a/src/features/notification/components/SettingRow.tsx
+++ b/src/features/notification/components/SettingRow.tsx
@@ -1,39 +1,45 @@
 import { ms } from "@/shared/constants/layout";
-import React from "react";
+import React, { memo } from "react";
 import { Switch, Text, XStack, YStack } from "tamagui";
 import { SettingRowProps } from "../types";
 
-export const SettingRow = ({
-  icon,
-  title,
-  description,
-  checked,
-  onCheckedChange,
-}: SettingRowProps) => (
-  <XStack jc="space-between" ai="center">
-    <XStack gap="$3" ai="center" f={1}>
-      <YStack backgroundColor="$iconBackground" p="$3" br="$4">
-        {icon}
-      </YStack>
-      <YStack f={1}>
-        <Text fontSize="$4" fontWeight="700">
-          {title}
-        </Text>
-        <Text fontSize="$3" color="$gray10">
-          {description}
-        </Text>
-      </YStack>
+export const SettingRow = memo(
+  ({
+    icon,
+    title,
+    description,
+    checked,
+    onCheckedChange,
+    disabled,
+  }: SettingRowProps) => (
+    <XStack jc="space-between" ai="center">
+      <XStack gap="$3" ai="center" f={1}>
+        <YStack backgroundColor="$iconBackground" p="$3" br="$4">
+          {icon}
+        </YStack>
+        <YStack f={1}>
+          <Text fontSize="$4" fontWeight="700">
+            {title}
+          </Text>
+          <Text fontSize="$3" color="$gray10">
+            {description}
+          </Text>
+        </YStack>
+      </XStack>
+      <Switch
+        size="$4"
+        checked={checked}
+        onCheckedChange={onCheckedChange}
+        disabled={disabled}
+        backgroundColor={checked ? "$primary" : "$gray4"}
+        height={ms(28)}
+        width={ms(46)}
+        p={ms(1)}
+      >
+        <Switch.Thumb size="$4" />
+      </Switch>
     </XStack>
-    <Switch
-      size="$4"
-      checked={checked}
-      onCheckedChange={onCheckedChange}
-      backgroundColor={checked ? "$primary" : "$gray4"}
-      height={ms(28)}
-      width={ms(46)}
-      p={ms(1)}
-    >
-      <Switch.Thumb size="$4" animation="quick" />
-    </Switch>
-  </XStack>
+  ),
 );
+
+SettingRow.displayName = "SettingRow";

--- a/src/features/notification/components/TimePicker/TimePickerSelect.tsx
+++ b/src/features/notification/components/TimePicker/TimePickerSelect.tsx
@@ -1,12 +1,16 @@
+import { getBottomPaddingForSheet } from "@/shared/constants/layout";
 import { ChevronRight } from "@tamagui/lucide-icons";
-import React, { useEffect, useState } from "react";
+import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Button, Sheet, Text, View, XStack, YStack } from "tamagui";
 import { AM_PM, HOURS, MINUTES, PICKER_ITEM_HEIGHT } from "../../constants";
+import { TimePickerSelectProps } from "../../types";
 import { PickerColumn } from "./PickerColumn";
-import { getBottomPaddingForSheet } from "@/shared/constants/layout";
 
-export const TimePickerSelect = ({ value, onValueChange }: any) => {
+const TimePickerSelectBase = ({
+  value,
+  onValueChange,
+}: TimePickerSelectProps) => {
   const [open, setOpen] = useState(false);
   const [tempValue, setTempValue] = useState(value);
   const insets = useSafeAreaInsets();
@@ -15,26 +19,34 @@ export const TimePickerSelect = ({ value, onValueChange }: any) => {
     if (open) setTempValue(value);
   }, [open, value]);
 
-  const parseValue = (val: string) => {
+  const parseValue = useCallback((val: string) => {
     const [h, m] = val.split(":").map(Number);
     return { isPm: h >= 12, hour: h % 12 === 0 ? 12 : h % 12, minute: m };
-  };
+  }, []);
 
-  const { isPm, hour, minute } = parseValue(tempValue);
+  const { isPm, hour, minute } = useMemo(
+    () => parseValue(tempValue),
+    [parseValue, tempValue],
+  );
 
-  const handleTempSelect = (changes: any) => {
-    const current = parseValue(tempValue);
-    const updated = { ...current, ...changes };
-    let finalHour = updated.hour % 12;
-    if (updated.isPm) finalHour += 12;
-    const formattedTime = `${String(finalHour).padStart(2, "0")}:${String(updated.minute).padStart(2, "0")}:00`;
-    setTempValue(formattedTime);
-  };
+  const display = useMemo(() => parseValue(value), [parseValue, value]);
 
-  const handleConfirm = () => {
+  const handleTempSelect = useCallback(
+    (changes: any) => {
+      const current = parseValue(tempValue);
+      const updated = { ...current, ...changes };
+      let finalHour = updated.hour % 12;
+      if (updated.isPm) finalHour += 12;
+      const formattedTime = `${String(finalHour).padStart(2, "0")}:${String(updated.minute).padStart(2, "0")}:00`;
+      setTempValue(formattedTime);
+    },
+    [parseValue, tempValue],
+  );
+
+  const handleConfirm = useCallback(() => {
     onValueChange(tempValue);
     setOpen(false);
-  };
+  }, [onValueChange, tempValue]);
 
   return (
     <>
@@ -51,103 +63,108 @@ export const TimePickerSelect = ({ value, onValueChange }: any) => {
         onPress={() => setOpen(true)}
       >
         <Text color="$primary" fontWeight="bold">
-          {parseValue(value).isPm ? "오후" : "오전"}{" "}
-          {String(parseValue(value).hour).padStart(2, "0")}:
-          {String(parseValue(value).minute).padStart(2, "0")}
+          {display.isPm ? "오후" : "오전"}{" "}
+          {String(display.hour).padStart(2, "0")}:
+          {String(display.minute).padStart(2, "0")}
         </Text>
       </Button>
 
-      <Sheet
-        modal
-        open={open}
-        onOpenChange={setOpen}
-        snapPoints={[40]}
-        dismissOnSnapToBottom
-        animation="quick"
-      >
-        <Sheet.Overlay
+      {open ? (
+        <Sheet
+          modal
+          open={open}
+          onOpenChange={setOpen}
+          snapPoints={[40]}
+          dismissOnSnapToBottom
           animation="quick"
-          enterStyle={{ opacity: 0 }}
-          exitStyle={{ opacity: 0 }}
-          backgroundColor="rgba(0, 0, 0, 0.5)"
-        />
-        <Sheet.Frame
-          p="$4"
-          pb={getBottomPaddingForSheet({
-            bottomInset: insets.bottom,
-          })}
-          backgroundColor="$background"
-          br="$5"
         >
-          <Sheet.Handle />
-          <YStack f={1} gap="$4" mt="$3" jc="center" ai="center">
-            <Text fontSize="$5" fontWeight="700" color="$mainText">
-              알림 시간 설정
-            </Text>
+          <Sheet.Overlay
+            animation="quick"
+            enterStyle={{ opacity: 0 }}
+            exitStyle={{ opacity: 0 }}
+            backgroundColor="rgba(0, 0, 0, 0.5)"
+          />
+          <Sheet.Frame
+            p="$4"
+            pb={getBottomPaddingForSheet({
+              bottomInset: insets.bottom,
+            })}
+            backgroundColor="$background"
+            br="$5"
+          >
+            <Sheet.Handle />
+            <YStack f={1} gap="$4" mt="$3" jc="center" ai="center">
+              <Text fontSize="$5" fontWeight="700" color="$mainText">
+                알림 시간 설정
+              </Text>
 
-            <XStack
-              f={1}
-              gap="$1"
-              jc="center"
-              ai="center"
-              h={PICKER_ITEM_HEIGHT * 3}
-              pos="relative"
-            >
-              <View
-                pos="absolute"
-                h={PICKER_ITEM_HEIGHT}
-                l={0}
-                r={0}
-                t="50%"
-                y="-50%"
-                backgroundColor="$gray2"
+              <XStack
+                f={1}
+                gap="$1"
+                jc="center"
+                ai="center"
+                h={PICKER_ITEM_HEIGHT * 3}
+                pos="relative"
+              >
+                <View
+                  pos="absolute"
+                  h={PICKER_ITEM_HEIGHT}
+                  l={0}
+                  r={0}
+                  t="50%"
+                  y="-50%"
+                  backgroundColor="$gray2"
+                  br="$3"
+                  zi={-1}
+                />
+
+                <PickerColumn
+                  items={AM_PM}
+                  selected={isPm ? "오후" : "오전"}
+                  onSelect={(val) => handleTempSelect({ isPm: val === "오후" })}
+                  width={80}
+                />
+                <Text fontSize="$5" fontWeight="300" color="$gray8" mx="$1">
+                  :
+                </Text>
+                <PickerColumn
+                  items={HOURS}
+                  selected={hour}
+                  onSelect={(val) => handleTempSelect({ hour: val })}
+                  format={(v) => String(v).padStart(2, "0")}
+                  width={60}
+                />
+                <Text fontSize="$5" fontWeight="300" color="$gray8" mx="$1">
+                  :
+                </Text>
+                <PickerColumn
+                  items={MINUTES}
+                  selected={minute}
+                  onSelect={(val) => handleTempSelect({ minute: val })}
+                  format={(v) => String(v).padStart(2, "0")}
+                  width={60}
+                />
+              </XStack>
+
+              <Button
+                mt="$4"
+                w="100%"
+                h={48}
                 br="$3"
-                zi={-1}
-              />
-
-              <PickerColumn
-                items={AM_PM}
-                selected={isPm ? "오후" : "오전"}
-                onSelect={(val) => handleTempSelect({ isPm: val === "오후" })}
-                width={80}
-              />
-              <Text fontSize="$5" fontWeight="300" color="$gray8" mx="$1">
-                :
-              </Text>
-              <PickerColumn
-                items={HOURS}
-                selected={hour}
-                onSelect={(val) => handleTempSelect({ hour: val })}
-                format={(v) => String(v).padStart(2, "0")}
-                width={60}
-              />
-              <Text fontSize="$5" fontWeight="300" color="$gray8" mx="$1">
-                :
-              </Text>
-              <PickerColumn
-                items={MINUTES}
-                selected={minute}
-                onSelect={(val) => handleTempSelect({ minute: val })}
-                format={(v) => String(v).padStart(2, "0")}
-                width={60}
-              />
-            </XStack>
-
-            <Button
-              mt="$4"
-              w="100%"
-              h={48}
-              br="$3"
-              onPress={handleConfirm}
-              backgroundColor="$primary"
-            >
-              <Text color="$white" fontWeight="bold" fontSize="$4">
-                확인
-              </Text>
-            </Button>
-          </YStack>
-        </Sheet.Frame>
-      </Sheet>
+                onPress={handleConfirm}
+                backgroundColor="$primary"
+              >
+                <Text color="$white" fontWeight="bold" fontSize="$4">
+                  확인
+                </Text>
+              </Button>
+            </YStack>
+          </Sheet.Frame>
+        </Sheet>
+      ) : null}
     </>
   );
 };
+
+export const TimePickerSelect = memo(TimePickerSelectBase);
+TimePickerSelect.displayName = "TimePickerSelect";

--- a/src/features/notification/components/TimePicker/TimePickerSelect.tsx
+++ b/src/features/notification/components/TimePicker/TimePickerSelect.tsx
@@ -10,6 +10,7 @@ import { PickerColumn } from "./PickerColumn";
 const TimePickerSelectBase = ({
   value,
   onValueChange,
+  disabled,
 }: TimePickerSelectProps) => {
   const [open, setOpen] = useState(false);
   const [tempValue, setTempValue] = useState(value);
@@ -60,7 +61,11 @@ const TimePickerSelectBase = ({
         iconAfter={<ChevronRight size={16} />}
         jc="space-between"
         px="$3"
-        onPress={() => setOpen(true)}
+        disabled={disabled}
+        onPress={() => {
+          if (disabled) return;
+          setOpen(true);
+        }}
       >
         <Text color="$primary" fontWeight="bold">
           {display.isPm ? "오후" : "오전"}{" "}

--- a/src/features/notification/hooks/mutations/useUpdateNotificationSettingMutation.ts
+++ b/src/features/notification/hooks/mutations/useUpdateNotificationSettingMutation.ts
@@ -5,23 +5,59 @@ import Toast from "react-native-toast-message";
 import { updateNotificationSettingsApi } from "../../apis/notification";
 import { NotificationSettingsRequest } from "../../apis/notification.types";
 
+type NotificationSettingsQueryData = { data: NotificationSettingsRequest };
+type MutationContext = { previous?: NotificationSettingsQueryData };
+
 const useUpdateNotificationSettingMutation = () => {
   const queryClient = useQueryClient();
 
   return useApiMutation<NotificationSettingsRequest, void>(
     updateNotificationSettingsApi(),
     {
-      onSuccess: () => {
-        queryClient.invalidateQueries({
-          queryKey: QUERY_KEYS.notification.settings(),
-        });
+      onMutate: async (nextSettings) => {
+        const queryKey = QUERY_KEYS.notification.settings();
+
+        await queryClient.cancelQueries({ queryKey });
+
+        const previous = queryClient.getQueryData<NotificationSettingsQueryData>(
+          queryKey,
+        );
+
+        // UI를 즉시 반영하기 위한 낙관적 업데이트
+        queryClient.setQueryData<NotificationSettingsQueryData>(
+          queryKey,
+          (old) => {
+            const current = old?.data ?? previous?.data;
+            if (!current) return old as any;
+            return {
+              ...old,
+              data: {
+                ...current,
+                ...nextSettings,
+              },
+            };
+          },
+        );
+
+        return { previous } satisfies MutationContext;
       },
-      onError: (error: any) => {
+      onError: (error: any, _variables, context) => {
+        const queryKey = QUERY_KEYS.notification.settings();
+        const ctx = context as MutationContext | undefined;
+        if (ctx?.previous) {
+          queryClient.setQueryData(queryKey, ctx.previous);
+        }
+
         const serverMessage = error.response?.data?.error?.message;
         Toast.show({
           type: "error",
           text1: "설정 업데이트 실패",
           text2: serverMessage || "알림 설정 업데이트 중 오류가 발생했습니다.",
+        });
+      },
+      onSettled: () => {
+        queryClient.invalidateQueries({
+          queryKey: QUERY_KEYS.notification.settings(),
         });
       },
     },

--- a/src/features/notification/hooks/mutations/useUpdateNotificationSettingMutation.ts
+++ b/src/features/notification/hooks/mutations/useUpdateNotificationSettingMutation.ts
@@ -11,7 +11,7 @@ type MutationContext = { previous?: NotificationSettingsQueryData };
 const useUpdateNotificationSettingMutation = () => {
   const queryClient = useQueryClient();
 
-  return useApiMutation<NotificationSettingsRequest, void>(
+  return useApiMutation<NotificationSettingsRequest, void, any, MutationContext>(
     updateNotificationSettingsApi(),
     {
       onMutate: async (nextSettings) => {
@@ -43,9 +43,8 @@ const useUpdateNotificationSettingMutation = () => {
       },
       onError: (error: any, _variables, context) => {
         const queryKey = QUERY_KEYS.notification.settings();
-        const ctx = context as MutationContext | undefined;
-        if (ctx?.previous) {
-          queryClient.setQueryData(queryKey, ctx.previous);
+        if (context?.previous) {
+          queryClient.setQueryData(queryKey, context.previous);
         }
 
         const serverMessage = error.response?.data?.error?.message;
@@ -55,7 +54,7 @@ const useUpdateNotificationSettingMutation = () => {
           text2: serverMessage || "알림 설정 업데이트 중 오류가 발생했습니다.",
         });
       },
-      onSettled: () => {
+      onSettled: (_data, _error, _variables, _context) => {
         queryClient.invalidateQueries({
           queryKey: QUERY_KEYS.notification.settings(),
         });

--- a/src/features/notification/hooks/useNotificationSettings.ts
+++ b/src/features/notification/hooks/useNotificationSettings.ts
@@ -1,25 +1,35 @@
 import { NotificationSettingsRequest } from "../apis/notification.types";
 import { useUpdateNotificationSettingMutation } from "./mutations/useUpdateNotificationSettingMutation";
 import { useNotificationSettingQuery } from "./queries/useNotificationSettingQuery";
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { QUERY_KEYS } from "@/shared/constants/queryKeys";
 
 const useNotificationSettings = () => {
+  const queryClient = useQueryClient();
   const query = useNotificationSettingQuery();
   const mutation = useUpdateNotificationSettingMutation();
 
   const settings = query.data?.data;
 
-  const updateSettings = (changes: Partial<NotificationSettingsRequest>) => {
-    if (!settings || mutation.isPending) {
-      return;
-    }
+  const updateSettings = useCallback(
+    (changes: Partial<NotificationSettingsRequest>) => {
+      const cached =
+        queryClient.getQueryData<{ data: NotificationSettingsRequest }>(
+          QUERY_KEYS.notification.settings(),
+        )?.data ?? settings;
 
-    mutation.mutate({
-      notificationTime: changes.notificationTime ?? settings.notificationTime,
-      daysBeforeExpiration:
-        changes.daysBeforeExpiration ?? settings.daysBeforeExpiration,
-      enabled: changes.enabled ?? settings.enabled,
-    });
-  };
+      if (!cached) return;
+
+      mutation.mutate({
+        notificationTime: changes.notificationTime ?? cached.notificationTime,
+        daysBeforeExpiration:
+          changes.daysBeforeExpiration ?? cached.daysBeforeExpiration,
+        enabled: changes.enabled ?? cached.enabled,
+      });
+    },
+    [mutation, queryClient, settings],
+  );
 
   return {
     ...query,

--- a/src/features/notification/screens/NotificationSettingScreen.tsx
+++ b/src/features/notification/screens/NotificationSettingScreen.tsx
@@ -153,6 +153,7 @@ export function NotificationSettingScreen() {
               <TimePickerSelect
                 value={settings.notificationTime}
                 onValueChange={handleTimeChange}
+                disabled={isUpdating}
               />
             </XStack>
           </Section>

--- a/src/features/notification/screens/NotificationSettingScreen.tsx
+++ b/src/features/notification/screens/NotificationSettingScreen.tsx
@@ -1,5 +1,5 @@
 import { Bell, Clock, Info, Users } from "@tamagui/lucide-icons";
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 import Toast from "react-native-toast-message";
 import {
   Button,
@@ -24,9 +24,10 @@ export function NotificationSettingScreen() {
     data: settings,
     isLoading,
     updateSettings,
+    isUpdating,
   } = useNotificationSettings();
 
-  const handleOpenNotificationSettings = async () => {
+  const handleOpenNotificationSettings = useCallback(async () => {
     try {
       await openNotificationSettings();
     } catch {
@@ -36,7 +37,29 @@ export function NotificationSettingScreen() {
         text2: "시스템 설정을 열 수 없습니다.",
       });
     }
-  };
+  }, []);
+
+  const bellIcon = useMemo(
+    () => <Bell size="$3" color="$primary" />,
+    [],
+  );
+  const usersIcon = useMemo(
+    () => <Users size="$3" color="$primary" />,
+    [],
+  );
+
+  const handleEnabledChange = useCallback(
+    (enabled: boolean) => updateSettings({ enabled }),
+    [updateSettings],
+  );
+  const handleDayPress = useCallback(
+    (day: number) => updateSettings({ daysBeforeExpiration: day }),
+    [updateSettings],
+  );
+  const handleTimeChange = useCallback(
+    (time: string) => updateSettings({ notificationTime: time }),
+    [updateSettings],
+  );
 
   if (isLoading || !settings) {
     return (
@@ -57,11 +80,12 @@ export function NotificationSettingScreen() {
         <YStack gap="$5">
           <Section label="식재료 관리 알림">
             <SettingRow
-              icon={<Bell size="$3" color="$primary" />}
+              icon={bellIcon}
               title="유통기한 임박 알림"
               description="식재료의 신선도를 유지하세요"
               checked={settings.enabled}
-              onCheckedChange={(enabled) => updateSettings({ enabled })}
+              onCheckedChange={handleEnabledChange}
+              disabled={isUpdating}
             />
 
             <YStack
@@ -84,9 +108,8 @@ export function NotificationSettingScreen() {
                     active={
                       settings.enabled && settings.daysBeforeExpiration === day
                     }
-                    onPress={() =>
-                      updateSettings({ daysBeforeExpiration: day })
-                    }
+                    onPress={() => handleDayPress(day)}
+                    disabled={isUpdating}
                   />
                 ))}
               </XStack>
@@ -95,10 +118,11 @@ export function NotificationSettingScreen() {
 
           <Section label="공유 및 활동">
             <SettingRow
-              icon={<Users size="$3" color="$primary" />}
+              icon={usersIcon}
               title="새로운 냉장고 멤버 참여"
               description="초대한 멤버가 수락하면 알려드려요"
               checked={true} //  현재는 고정값
+              disabled
             />
           </Section>
 
@@ -128,9 +152,7 @@ export function NotificationSettingScreen() {
 
               <TimePickerSelect
                 value={settings.notificationTime}
-                onValueChange={(time: string) =>
-                  updateSettings({ notificationTime: time })
-                }
+                onValueChange={handleTimeChange}
               />
             </XStack>
           </Section>

--- a/src/features/notification/types/index.ts
+++ b/src/features/notification/types/index.ts
@@ -37,6 +37,7 @@ interface NotificationItemProps {
 interface TimePickerSelectProps {
   value: string;
   onValueChange: (time: string) => void;
+  disabled?: boolean;
 }
 
 export type {

--- a/src/features/notification/types/index.ts
+++ b/src/features/notification/types/index.ts
@@ -12,6 +12,7 @@ interface DayButtonProps {
   day: number;
   active: boolean;
   onPress: () => void;
+  disabled?: boolean;
 }
 
 interface SettingRowProps {
@@ -20,6 +21,7 @@ interface SettingRowProps {
   description: string;
   checked: boolean;
   onCheckedChange?: (checked: boolean) => void;
+  disabled?: boolean;
 }
 
 interface NotificationItemProps {
@@ -32,9 +34,15 @@ interface NotificationItemProps {
   messageId?: string;
 }
 
+interface TimePickerSelectProps {
+  value: string;
+  onValueChange: (time: string) => void;
+}
+
 export type {
   DayButtonProps,
   NotificationItemProps,
   PickerColumnProps,
   SettingRowProps,
+  TimePickerSelectProps,
 };

--- a/src/shared/apis/builder/ApiBuilder.ts
+++ b/src/shared/apis/builder/ApiBuilder.ts
@@ -89,11 +89,11 @@ export function useApiQuery<T, R, TError = Error>(
   });
 }
 
-export function useApiMutation<T, R, TError = Error>(
+export function useApiMutation<T, R, TError = Error, TContext = unknown>(
   apiBuilder: ApiBuilder<T, R>,
-  options?: UseMutationOptions<R, TError, T>,
+  options?: UseMutationOptions<R, TError, T, TContext>,
 ) {
-  return useMutation<R, TError, T>({
+  return useMutation<R, TError, T, TContext>({
     mutationFn: apiBuilder.getMutationFn(),
     ...options,
   });


### PR DESCRIPTION
## 작업 내용

- 알림 설정 변경 시 UI가 서버 응답을 기다리지 않고 즉시 반영되도록 낙관적 업데이트 적용
- 불필요한 refetch/리렌더를 줄여 터치 반응 및 스크롤/전환 체감 개선
- TimePicker Sheet를 open 시에만 마운트하도록 변경해 기본 화면 비용 절감


## 연관 이슈

- #109


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 알림 설정 업데이트 시 낙관적 UI 적용으로 변경사항이 즉시 표시됩니다.

* **개선사항**
  * 설정 업데이트 중 관련 컨트롤이 비활성화되어 사용자 의도하지 않은 조작을 방지합니다.
  * 렌더링 성능 최적화를 위해 주요 컴포넌트에 메모이제이션을 적용했습니다.
  * 플랫폼별 개발 환경 설정이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->