### PR TITLE
Chore: placeholder 텍스트 크기 변경 및 냉장고 이름 수정 모달 텍스트 크기 변경

### DIFF
--- a/src/features/food-add/components/CategorySelector/CategoryFormSheet.tsx
+++ b/src/features/food-add/components/CategorySelector/CategoryFormSheet.tsx
@@ -1,3 +1,4 @@
+import { getBottomPaddingForSheet, ms, s } from "@/shared/constants/layout";
 import React, { useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import {
@@ -19,7 +20,6 @@ import {
   YStack,
 } from "tamagui";
 import { CategoryFormSheetProps, CategoryFormValues } from "../../types";
-import { getBottomPaddingForSheet, ms, s } from "@/shared/constants/layout";
 
 export const CategoryFormSheet = ({
   visible,
@@ -167,7 +167,7 @@ export const CategoryFormSheet = ({
                         br="$4"
                         bw={errors.name ? 1 : 0}
                         boc="$warning"
-                        fontSize="$4"
+                        fontSize="$2"
                         fontFamily="$baemin"
                         onSubmitEditing={handleSubmit(onSubmit)}
                         returnKeyType="done"

--- a/src/features/food-add/components/FoodNameInput.tsx
+++ b/src/features/food-add/components/FoodNameInput.tsx
@@ -1,8 +1,8 @@
+import { ms } from "@/shared/constants/layout";
 import React from "react";
 import { Control, Controller } from "react-hook-form";
 import { Input, Text, YStack, styled, useThemeName } from "tamagui";
 import { FoodFormValues } from "../types";
-import { ms } from "@/shared/constants/layout";
 
 const LabelText = styled(Text, {
   fontFamily: "$heading",
@@ -43,7 +43,7 @@ export const FoodNameInput = ({
             placeholder="식품 이름을 입력하세요"
             placeholderTextColor={themeName === "dark" ? "$gray10" : "$gray5"}
             backgroundColor="$gray3"
-            fontSize="$3"
+            fontSize="$2"
             fontFamily="$baemin"
             fontWeight="400"
             br="$4"

--- a/src/features/fridge-management/components/FridgeNameEditSheet.tsx
+++ b/src/features/fridge-management/components/FridgeNameEditSheet.tsx
@@ -1,3 +1,4 @@
+import { fs, getBottomPaddingForSheet, ms, s } from "@/shared/constants/layout";
 import React, { useEffect, useState } from "react";
 import {
   KeyboardAvoidingView,
@@ -9,7 +10,6 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { AnimatePresence, Button, Input, Text, View, YStack } from "tamagui";
 import { FridgeNameEditSheetProps } from "../types";
-import { fs, getBottomPaddingForSheet, ms, s } from "@/shared/constants/layout";
 
 export const FridgeNameEditSheet = ({
   visible,
@@ -87,7 +87,7 @@ export const FridgeNameEditSheet = ({
                 />
 
                 <YStack gap="$2">
-                  <Text fontSize="$6" fontWeight="700" fontFamily="$baemin">
+                  <Text fontSize="$4" fontWeight="700" fontFamily="$baemin">
                     냉장고 이름 수정
                   </Text>
                   <Text fontSize="$3" color="$gray10">
@@ -104,7 +104,8 @@ export const FridgeNameEditSheet = ({
                     onChangeText={setNewName}
                     autoFocus
                     maxLength={15}
-                    fontSize="$3"
+                    fontSize="$2"
+                    fontFamily="$baemin"
                     backgroundColor="$gray3"
                   />
 

--- a/src/features/fridge-management/screens/FridgeAddScreen.tsx
+++ b/src/features/fridge-management/screens/FridgeAddScreen.tsx
@@ -1,8 +1,8 @@
 import { Header } from "@/shared/components/Header/Header";
+import { fs, ms } from "@/shared/constants/layout";
 import { useState } from "react";
 import { Button, Input, Text, YStack } from "tamagui";
 import { useJoinFridgeByInviteCodeMutation } from "../hooks/mutations/useJoinFridgeByInviteCodeMutation";
-import { fs, ms } from "@/shared/constants/layout";
 
 export function FridgeAddScreen() {
   const [inviteCode, setInviteCode] = useState("");
@@ -36,7 +36,7 @@ export function FridgeAddScreen() {
           fontFamily="$baemin"
           h={ms(50)}
           br="$4"
-          fontSize="$5"
+          fontSize="$2"
           placeholder="초대코드 입력"
           value={inviteCode}
           onChangeText={handleTextChange}


### PR DESCRIPTION
## 작업 내용

placeholder(input)
- 카테고리 추가 바텀시트 placeholder 크기 변경
- 냉장고 이름 수정 바텀시트 placeholder 및 텍스트 크기 변경
- 냉장고 추가 페이지 placeholder  크기 변경
- 식품 이름 placeholder 크기 변경

## 연관 이슈

- #114


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일

* 입력 필드의 글꼴 크기를 조정하여 UI의 시각적 계층을 개선했습니다.
* 여러 화면의 제목 텍스트 크기를 줄였습니다.
* 전반적인 인터페이스의 가독성과 일관성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->