### PR TITLE
Fix: 캘린더 날짜 재선택 시 선택 표시(원형)가 사각형으로 깨지는 문제 수정

### DIFF
--- a/src/features/calendar/components/CalendarMonthView.tsx
+++ b/src/features/calendar/components/CalendarMonthView.tsx
@@ -67,7 +67,7 @@ export function CalendarMonthView({
               <RNView
                 style={[
                   styles.dayCircle,
-                  isSelected && { backgroundColor: selectedDayBg },
+                  isSelected && { backgroundColor: selectedDayBg, borderRadius: 9999 },
                   isDimmed && styles.dayCircleDisabled,
                 ]}
               >

--- a/src/features/calendar/utils/calendar.ts
+++ b/src/features/calendar/utils/calendar.ts
@@ -30,7 +30,6 @@ export const buildMarkedDates = (foods: FoodItem[], selectedDate: string) => {
     {
       dots: { key: string; color: string }[];
       selected?: boolean;
-      selectedColor?: string;
     }
   > = {};
 
@@ -49,7 +48,6 @@ export const buildMarkedDates = (foods: FoodItem[], selectedDate: string) => {
   marks[selectedDate] = {
     ...(marks[selectedDate] || { dots: [] }),
     selected: true,
-    selectedColor: "#2EE6A8",
   };
 
   return marks;


### PR DESCRIPTION
## 작업 내용

- markedDates에 넣던 selectedColor를 제거해서 라이브러리 기본 선택 배경이 같이 그려지지 않게 변경
- 선택 상태에서 borderRadius를 한 번 더 강제로 지정해 깨질 여지를 줄임

## 연관 이슈

- #117


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일
* 달력에서 선택된 날짜 표시기가 완전히 둥근 원형 모양으로 개선되었습니다.
* 선택된 날짜의 색상 커스터마이징 기능이 제거되어 통일된 색상이 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->