### PR TITLE
[#119] Chore: 온보딩 페이지 레이아웃 수정

### DIFF
--- a/src/features/onboarding/components/OnboardingItem.tsx
+++ b/src/features/onboarding/components/OnboardingItem.tsx
@@ -8,8 +8,8 @@ export function OnboardingItem({ item, isDark }: OnboardingItemProps) {
   const { width: screenWidth } = useWindowDimensions();
   const imageHeight = ms(280);
   return (
-    <View w={screenWidth} px="$6">
-      <YStack pt="$5" ai="center">
+    <View w={screenWidth} px="$6" f={1}>
+      <YStack f={1} ai="center" jc="center">
         <View
           w="100%"
           h={imageHeight}


### PR DESCRIPTION
## 작업 내용

- 온보딩 페이지의 사진, 텍스트를 상단에서 화면 중앙으로 오게끔 수정

## 연관 이슈

- #119


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **스타일**
  * 온보딩 화면의 요소들이 화면 공간을 더 효율적으로 활용하도록 레이아웃을 개선했습니다.
  * 콘텐츠가 화면에서 더 나은 위치에 수직 정렬됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->