### PR TITLE
Feat: 이미지 등록에 카메라 촬영/앨범 선택 추가

### DIFF
--- a/src/features/food-add/components/ImageUploader.tsx
+++ b/src/features/food-add/components/ImageUploader.tsx
@@ -1,36 +1,23 @@
 import { Camera } from "@tamagui/lucide-icons";
-import * as ImagePicker from "expo-image-picker";
 import { Control, Controller } from "react-hook-form";
 import { Circle, Image, Text, YStack } from "tamagui";
 import { FoodFormValues } from "../types";
 import { fs, ms, s } from "@/shared/constants/layout";
+import { useImagePickerActions } from "@/shared/hooks/useImagePickerActions";
 
 export const ImageUploader = ({
   control,
 }: {
   control: Control<FoodFormValues>;
 }) => {
-  const handlePickImage = async (onChange: (uri: string) => void) => {
-    const permissionResult =
-      await ImagePicker.requestMediaLibraryPermissionsAsync();
-
-    if (permissionResult.granted === false) {
-      alert("사진첩 접근 권한이 거부되었습니다.");
-      return;
-    }
-
-    // NOTE: 이미지 선택기 (아래 옵션들 수정 예정)
-    const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: "images",
-      allowsEditing: true, // 크롭 등 편집 허용
-      aspect: [1, 1], // 1:1 비율로 제한
-      quality: 1, // 화질 설정 (0~1)
+  const handlePickImage = (onChange: (uri: string) => void) => {
+    showPickerAlert({
+      onPicked: (asset) => onChange(asset.uri),
+      options: { allowsEditing: true, aspect: [1, 1], quality: 1 },
     });
-
-    if (!result.canceled) {
-      onChange(result.assets[0].uri);
-    }
   };
+
+  const { showPickerAlert } = useImagePickerActions();
 
   return (
     <Controller

--- a/src/features/profile/screens/ProfileScreen.tsx
+++ b/src/features/profile/screens/ProfileScreen.tsx
@@ -13,10 +13,9 @@ import {
   Palette,
   Refrigerator,
 } from "@tamagui/lucide-icons";
-import * as ImagePicker from "expo-image-picker";
 import { useRouter } from "expo-router";
 import React, { useEffect } from "react";
-import { Alert, Linking } from "react-native";
+import { Linking } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   Avatar,
@@ -39,6 +38,7 @@ import {
   getSavedProfileImage,
   saveProfileImageIndex,
 } from "../utils/getRandomDefaultProfileImage";
+import { useImagePickerActions } from "@/shared/hooks/useImagePickerActions";
 
 export function ProfileScreen() {
   const insets = useSafeAreaInsets();
@@ -61,6 +61,7 @@ export function ProfileScreen() {
   const nickname = memberProfile?.data?.nickname ?? "Fridgely";
   const { mutate: updateProfileImage, isPending: isUpdatingProfileImage } =
     useUpdateProfileImageMutation(loginId);
+  const { showPickerAlert } = useImagePickerActions();
   const [profileImageSource, setProfileImageSource] = React.useState<
     any | null
   >(null);
@@ -116,37 +117,17 @@ export function ProfileScreen() {
   };
 
   const handleProfileImageUpdate = async () => {
-    const permissionResult =
-      await ImagePicker.requestMediaLibraryPermissionsAsync();
-
-    if (!permissionResult.granted) {
-      Alert.alert(
-        "권한 필요",
-        "프로필 사진 변경을 위해 사진첩 접근 권한이 필요합니다.",
-      );
-      return;
-    }
-
-    const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: "images",
-      allowsEditing: true,
-      aspect: [1, 1],
-      quality: 1,
-    });
-
-    if (result.canceled) {
-      return;
-    }
-
-    const selectedAsset = result.assets?.[0];
-    if (!selectedAsset?.uri) {
-      return;
-    }
-
-    updateProfileImage({
-      uri: selectedAsset.uri,
-      fileName: selectedAsset.fileName,
-      mimeType: selectedAsset.mimeType,
+    showPickerAlert({
+      title: "프로필 사진 변경",
+      message: "원하는 방법을 선택하세요.",
+      options: { allowsEditing: true, aspect: [1, 1], quality: 1 },
+      onPicked: (asset) => {
+        updateProfileImage({
+          uri: asset.uri,
+          fileName: asset.fileName ?? undefined,
+          mimeType: asset.mimeType ?? undefined,
+        });
+      },
     });
   };
 

--- a/src/shared/components/Header/Header.tsx
+++ b/src/shared/components/Header/Header.tsx
@@ -42,6 +42,8 @@ export function Header({
               color="$mainText"
               letterSpacing={-0.5}
               fontSize={fs(20)}
+              numberOfLines={1}
+              ellipsizeMode="tail"
             >
               {title}
             </Heading>
@@ -49,7 +51,15 @@ export function Header({
         </XStack>
 
         {showBackButton && (
-          <Heading size="$5" fontWeight="700" color="$mainText" fontSize={fs(18)}>
+          <Heading
+            size="$5"
+            fontWeight="700"
+            color="$mainText"
+            fontSize={fs(18)}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            style={{ maxWidth: "70%" }}
+          >
             {title}
           </Heading>
         )}

--- a/src/shared/components/Header/Header.tsx
+++ b/src/shared/components/Header/Header.tsx
@@ -1,11 +1,11 @@
 import { useNotificationStore } from "@/features/notification/stores/useNotificationStore";
+import { fs, ms, s } from "@/shared/constants/layout";
 import { Bell, ChevronLeft } from "@tamagui/lucide-icons";
 import { useRouter } from "expo-router";
 import React from "react";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Button, Heading, View, XStack } from "tamagui";
 import { HeaderProps } from "./Header.types";
-import { fs, ms, s } from "@/shared/constants/layout";
 export function Header({
   title = "Fridgely",
   showBackButton = false,
@@ -41,7 +41,7 @@ export function Header({
               fontWeight="700"
               color="$mainText"
               letterSpacing={-0.5}
-              fontSize={fs(20)}
+              fontSize={fs(18)}
               numberOfLines={1}
               ellipsizeMode="tail"
             >

--- a/src/shared/hooks/useImagePickerActions.ts
+++ b/src/shared/hooks/useImagePickerActions.ts
@@ -1,0 +1,135 @@
+import { Alert, Linking } from "react-native";
+import * as ImagePicker from "expo-image-picker";
+
+type PickerOptions = {
+  allowsEditing?: boolean;
+  aspect?: [number, number];
+  quality?: number;
+};
+
+export type PickedImageAsset = {
+  uri: string;
+  fileName?: string | null;
+  mimeType?: string | null;
+};
+
+const defaultOptions: Required<PickerOptions> = {
+  allowsEditing: true,
+  aspect: [1, 1],
+  quality: 1,
+};
+
+function openPermissionSettings() {
+  Linking.openSettings();
+}
+
+function normalizeOptions(options?: PickerOptions): Required<PickerOptions> {
+  return {
+    allowsEditing: options?.allowsEditing ?? defaultOptions.allowsEditing,
+    aspect: options?.aspect ?? defaultOptions.aspect,
+    quality: options?.quality ?? defaultOptions.quality,
+  };
+}
+
+function getSelectedAsset(
+  result: ImagePicker.ImagePickerResult,
+): PickedImageAsset | null {
+  if (result.canceled) return null;
+  const asset = result.assets?.[0];
+  if (!asset?.uri) return null;
+
+  return {
+    uri: asset.uri,
+    fileName: asset.fileName ?? null,
+    mimeType: asset.mimeType ?? null,
+  };
+}
+
+export function useImagePickerActions() {
+  const pickFromLibrary = async (
+    options?: PickerOptions,
+  ): Promise<PickedImageAsset | null> => {
+    const permissionResult =
+      await ImagePicker.requestMediaLibraryPermissionsAsync();
+
+    if (!permissionResult.granted) {
+      Alert.alert(
+        "권한 필요",
+        "사진을 등록하려면 사진첩 접근 권한이 필요합니다.",
+        [
+          { text: "취소", style: "cancel" },
+          { text: "설정으로 이동", onPress: openPermissionSettings },
+        ],
+      );
+      return null;
+    }
+
+    const normalized = normalizeOptions(options);
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: "images",
+      allowsEditing: normalized.allowsEditing,
+      aspect: normalized.aspect,
+      quality: normalized.quality,
+    });
+
+    return getSelectedAsset(result);
+  };
+
+  const pickFromCamera = async (
+    options?: PickerOptions,
+  ): Promise<PickedImageAsset | null> => {
+    const permissionResult = await ImagePicker.requestCameraPermissionsAsync();
+
+    if (!permissionResult.granted) {
+      Alert.alert(
+        "권한 필요",
+        "사진을 촬영하려면 카메라 접근 권한이 필요합니다.",
+        [
+          { text: "취소", style: "cancel" },
+          { text: "설정으로 이동", onPress: openPermissionSettings },
+        ],
+      );
+      return null;
+    }
+
+    const normalized = normalizeOptions(options);
+    const result = await ImagePicker.launchCameraAsync({
+      allowsEditing: normalized.allowsEditing,
+      aspect: normalized.aspect,
+      quality: normalized.quality,
+    });
+
+    return getSelectedAsset(result);
+  };
+
+  const showPickerAlert = (params: {
+    title?: string;
+    message?: string;
+    options?: PickerOptions;
+    onPicked: (asset: PickedImageAsset) => void | Promise<void>;
+  }) => {
+    const title = params.title ?? "사진 등록";
+    const message = params.message ?? "원하는 방법을 선택하세요.";
+
+    Alert.alert(title, message, [
+      { text: "취소", style: "cancel" },
+      {
+        text: "카메라로 촬영",
+        onPress: async () => {
+          const asset = await pickFromCamera(params.options);
+          if (asset) await params.onPicked(asset);
+        },
+      },
+      {
+        text: "앨범에서 선택",
+        onPress: async () => {
+          const asset = await pickFromLibrary(params.options);
+          if (asset) await params.onPicked(asset);
+        },
+      },
+    ]);
+  };
+
+  return { pickFromLibrary, pickFromCamera, showPickerAlert };
+}
+

--- a/src/shared/hooks/useImagePickerActions.ts
+++ b/src/shared/hooks/useImagePickerActions.ts
@@ -66,7 +66,7 @@ export function useImagePickerActions() {
 
     const normalized = normalizeOptions(options);
     const result = await ImagePicker.launchImageLibraryAsync({
-      mediaTypes: "images",
+      mediaTypes: ["images"],
       allowsEditing: normalized.allowsEditing,
       aspect: normalized.aspect,
       quality: normalized.quality,


### PR DESCRIPTION
## 작업 내용

- 식품 이미지 등록 및 프로필 사진 등록에 카메라 촬영/앨범 선택 추가
- 이미지 피커 로직을 공용 훅으로 분리
- 헤더 줄바꿈 방지

## 연관 이슈

- #121


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 헤더 제목이 한 줄로 고정되고 말줄임표로 처리되어 레이아웃 깨짐 방지
  * 뒤로가기 버튼 있을 때 제목 너비를 제한해 겹침 제거

* **개선**
  * 이미지 선택 흐름 통합: 카메라/앨범 선택 UI 제공 및 일관된 편집(1:1, 전체 화질) 적용
  * 권한 거부 시 설정 열기 안내 알림 표시
  * 프로필 및 이미지 업로더에서 동일한 이미지 선택 경험 사용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->