### PR TITLE
Feat: 프로필/식품 업로드 이미지 리사이즈 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "expo-font": "~14.0.10",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
+        "expo-image-manipulator": "~14.0.8",
         "expo-image-picker": "~17.0.10",
         "expo-linking": "~8.0.11",
         "expo-notifications": "~0.32.16",
@@ -9910,6 +9911,17 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-6.0.0.tgz",
       "integrity": "sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-manipulator": {
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-14.0.8.tgz",
+      "integrity": "sha512-sXsXjm7rIxLWZe0j2A41J/Ph53PpFJRdyzJ3EQ/qetxLUvS2m3K1sP5xy37px43qCf0l79N/i6XgFgenFV36/Q==",
+      "dependencies": {
+        "expo-image-loader": "~6.0.0"
+      },
       "peerDependencies": {
         "expo": "*"
       }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "expo-font": "~14.0.10",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
+    "expo-image-manipulator": "~14.0.8",
     "expo-image-picker": "~17.0.10",
     "expo-linking": "~8.0.11",
     "expo-notifications": "~0.32.16",

--- a/src/features/food-add/hooks/mutations/useAddFoodMutation.ts
+++ b/src/features/food-add/hooks/mutations/useAddFoodMutation.ts
@@ -2,6 +2,7 @@ import { addFoodApi } from "@/features/food-add/apis/food";
 import { FoodFormValues } from "@/features/food-add/types";
 import { useApiMutation } from "@/shared/apis/builder/ApiBuilder";
 import { QUERY_KEYS } from "@/shared/constants/queryKeys";
+import { resizeImageForUpload } from "@/shared/lib/image/resizeImageForUpload";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import Toast from "react-native-toast-message";
@@ -69,23 +70,37 @@ const useAddFoodMutation = (fridgeId: number) => {
       type: "application/json",
     } as any);
 
-    if (values.imageURL) {
-      const uri = values.imageURL;
-      const fileName = uri.split("/").pop() || `food_${Date.now()}.jpg`;
+    (async () => {
+      if (values.imageURL) {
+        try {
+          const resized = await resizeImageForUpload({
+            uri: values.imageURL,
+            maxSize: 1280,
+          });
+          formData.append("image", {
+            uri: resized.uri,
+            name: resized.fileName,
+            type: resized.mimeType,
+          } as any);
+        } catch {
+          const uri = values.imageURL;
+          const fileName = uri.split("/").pop() || `food_${Date.now()}.jpg`;
 
-      const extension = fileName.split(".").pop()?.toLowerCase();
-      let mimeType = "image/jpeg"; // 기본값
-      if (extension === "png") mimeType = "image/png";
-      if (extension === "gif") mimeType = "image/gif";
+          const extension = fileName.split(".").pop()?.toLowerCase();
+          let mimeType = "image/jpeg"; // 기본값
+          if (extension === "png") mimeType = "image/png";
+          if (extension === "gif") mimeType = "image/gif";
 
-      formData.append("image", {
-        uri: uri,
-        name: fileName,
-        type: mimeType, // image/jpeg, image/png 등
-      } as any);
-    }
+          formData.append("image", {
+            uri: uri,
+            name: fileName,
+            type: mimeType, // image/jpeg, image/png 등
+          } as any);
+        }
+      }
 
-    return mutation.mutate(formData);
+      mutation.mutate(formData);
+    })();
   };
 
   return { ...mutation, mutate: addFood };

--- a/src/features/food-edit/hooks/mutations/useUpdateFoodMutation.ts
+++ b/src/features/food-edit/hooks/mutations/useUpdateFoodMutation.ts
@@ -1,6 +1,7 @@
 import { FoodFormValues } from "@/features/food-add/types";
 import { useApiMutation } from "@/shared/apis/builder/ApiBuilder";
 import { QUERY_KEYS } from "@/shared/constants/queryKeys";
+import { resizeImageForUpload } from "@/shared/lib/image/resizeImageForUpload";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import Toast from "react-native-toast-message";
@@ -84,23 +85,37 @@ const useUpdateFoodMutation = (fridgeId: number, foodId: number) => {
       type: "application/json",
     } as any);
 
-    if (values.imageURL) {
-      const uri = values.imageURL;
-      const fileName = uri.split("/").pop() || `food_${Date.now()}.jpg`;
+    (async () => {
+      if (values.imageURL) {
+        try {
+          const resized = await resizeImageForUpload({
+            uri: values.imageURL,
+            maxSize: 1280,
+          });
+          formData.append("image", {
+            uri: resized.uri,
+            name: resized.fileName,
+            type: resized.mimeType,
+          } as any);
+        } catch {
+          const uri = values.imageURL;
+          const fileName = uri.split("/").pop() || `food_${Date.now()}.jpg`;
 
-      const extension = fileName.split(".").pop()?.toLowerCase();
-      let mimeType = "image/jpeg";
-      if (extension === "png") mimeType = "image/png";
-      if (extension === "gif") mimeType = "image/gif";
+          const extension = fileName.split(".").pop()?.toLowerCase();
+          let mimeType = "image/jpeg";
+          if (extension === "png") mimeType = "image/png";
+          if (extension === "gif") mimeType = "image/gif";
 
-      formData.append("image", {
-        uri,
-        name: fileName,
-        type: mimeType,
-      } as any);
-    }
+          formData.append("image", {
+            uri,
+            name: fileName,
+            type: mimeType,
+          } as any);
+        }
+      }
 
-    return mutation.mutate(formData);
+      mutation.mutate(formData);
+    })();
   };
 
   return { ...mutation, mutate: updateFood };

--- a/src/features/profile/hooks/useUpdateProfileImageMutation.ts
+++ b/src/features/profile/hooks/useUpdateProfileImageMutation.ts
@@ -1,4 +1,5 @@
 import { QUERY_KEYS } from "@/shared/constants/queryKeys";
+import { resizeImageForUpload } from "@/shared/lib/image/resizeImageForUpload";
 import { tokenStorage } from "@/shared/lib/tokenStorage/tokenStorage";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import Toast from "react-native-toast-message";
@@ -44,18 +45,28 @@ const useUpdateProfileImageMutation = (loginId: string) => {
       });
 
       if (!response.ok) {
+        const contentType = response.headers.get("content-type") || "";
         let errorData: any = null;
+        let errorText: string | null = null;
 
         try {
-          errorData = await response.json();
+          if (contentType.includes("application/json")) {
+            errorData = await response.json();
+          } else {
+            errorText = await response.text();
+          }
         } catch {
-          errorData = null;
+          try {
+            errorText = await response.text();
+          } catch {
+            errorText = null;
+          }
         }
 
         throw {
           response: {
             status: response.status,
-            data: errorData,
+            data: errorData ?? { raw: errorText },
           },
         };
       }
@@ -77,11 +88,18 @@ const useUpdateProfileImageMutation = (loginId: string) => {
     },
     onError: (error: any, _variables, _onMutateResult, _context) => {
       const serverMessage = error.response?.data?.error?.message;
+      const rawMessage =
+        typeof error.response?.data?.raw === "string"
+          ? error.response.data.raw
+          : null;
 
       Toast.show({
         type: "error",
         text1: "프로필 사진 수정 실패",
-        text2: serverMessage || "프로필 사진 업로드 중 오류가 발생했습니다.",
+        text2:
+          serverMessage ||
+          rawMessage ||
+          "프로필 사진 업로드 중 오류가 발생했습니다.",
       });
     },
   });
@@ -91,18 +109,30 @@ const useUpdateProfileImageMutation = (loginId: string) => {
     fileName: inputFileName,
     mimeType,
   }: ProfileImageUploadInput) => {
-    const fileName =
-      inputFileName || uri.split("/").pop() || `profile_${Date.now()}.jpg`;
-    const type = getMimeType(fileName, mimeType);
+    (async () => {
+      let finalUri = uri;
+      let fileName =
+        inputFileName || uri.split("/").pop() || `profile_${Date.now()}.jpg`;
+      let type = getMimeType(fileName, mimeType);
 
-    const formData = new FormData();
-    formData.append("file", {
-      uri,
-      type,
-      name: fileName,
-    } as any);
+      try {
+        const resized = await resizeImageForUpload({ uri, maxSize: 1280 });
+        finalUri = resized.uri;
+        fileName = resized.fileName;
+        type = resized.mimeType;
+      } catch {
+        // 리사이징 실패 시 원본으로 업로드
+      }
 
-    mutation.mutate(formData);
+      const formData = new FormData();
+      formData.append("file", {
+        uri: finalUri,
+        type,
+        name: fileName,
+      } as any);
+
+      mutation.mutate(formData);
+    })();
   };
 
   return { ...mutation, mutate: updateProfileImage };

--- a/src/shared/lib/image/resizeImageForUpload.ts
+++ b/src/shared/lib/image/resizeImageForUpload.ts
@@ -1,0 +1,78 @@
+export type ResizeImageForUploadParams = {
+  uri: string;
+  /**
+   * 긴 변 기준 최대 크기. 기본 1280
+   */
+  maxSize?: number;
+  /**
+   * JPEG 압축률 (0~1). 기본 0.8
+   */
+  compress?: number;
+};
+
+export type ResizedImage = {
+  uri: string;
+  fileName: string;
+  mimeType: "image/jpeg";
+};
+
+async function getImageSize(
+  uri: string,
+): Promise<{ width: number; height: number }> {
+  const { Image } = await import("react-native");
+
+  return await new Promise((resolve, reject) => {
+    Image.getSize(
+      uri,
+      (width, height) => resolve({ width, height }),
+      (error) => reject(error),
+    );
+  });
+}
+
+export async function resizeImageForUpload(
+  params: ResizeImageForUploadParams,
+): Promise<ResizedImage> {
+  let ImageManipulator: typeof import("expo-image-manipulator");
+  try {
+    ImageManipulator = await import("expo-image-manipulator");
+  } catch {
+    throw new Error("ExpoImageManipulator native module not available");
+  }
+
+  const maxSize = params.maxSize ?? 1280;
+  const compress = params.compress ?? 0.8;
+
+  let width: number | null = null;
+  let height: number | null = null;
+
+  try {
+    const size = await getImageSize(params.uri);
+    width = size.width;
+    height = size.height;
+  } catch {}
+
+  const longSide =
+    width != null && height != null ? Math.max(width, height) : null;
+  const shouldResize = longSide == null ? true : longSide > maxSize;
+  const resizeAction = !shouldResize
+    ? []
+    : width != null && height != null && height > width
+      ? [{ resize: { height: maxSize } }]
+      : [{ resize: { width: maxSize } }];
+
+  const result = await ImageManipulator.manipulateAsync(
+    params.uri,
+    resizeAction,
+    {
+      compress,
+      format: ImageManipulator.SaveFormat.JPEG,
+    },
+  );
+
+  return {
+    uri: result.uri,
+    fileName: `image_${Date.now()}.jpg`,
+    mimeType: "image/jpeg",
+  };
+}

--- a/src/shared/lib/image/resizeImageForUpload.ts
+++ b/src/shared/lib/image/resizeImageForUpload.ts
@@ -43,6 +43,13 @@ export async function resizeImageForUpload(
   const maxSize = params.maxSize ?? 1280;
   const compress = params.compress ?? 0.8;
 
+  if (!Number.isFinite(maxSize) || maxSize <= 0) {
+    throw new Error("maxSize must be a positive number");
+  }
+  if (!Number.isFinite(compress) || compress < 0 || compress > 1) {
+    throw new Error("compress must be between 0 and 1");
+  }
+
   let width: number | null = null;
   let height: number | null = null;
 

--- a/src/shared/lib/image/resizeImageForUpload.ts
+++ b/src/shared/lib/image/resizeImageForUpload.ts
@@ -61,12 +61,13 @@ export async function resizeImageForUpload(
 
   const longSide =
     width != null && height != null ? Math.max(width, height) : null;
-  const shouldResize = longSide == null ? true : longSide > maxSize;
-  const resizeAction = !shouldResize
-    ? []
-    : width != null && height != null && height > width
-      ? [{ resize: { height: maxSize } }]
-      : [{ resize: { width: maxSize } }];
+  const shouldResize = longSide != null && longSide > maxSize;
+  const resizeAction =
+    shouldResize && width != null && height != null
+      ? height > width
+        ? [{ resize: { height: maxSize } }]
+        : [{ resize: { width: maxSize } }]
+      : [];
 
   const result = await ImageManipulator.manipulateAsync(
     params.uri,


### PR DESCRIPTION
## 작업 내용

- 공용 resizeImageForUpload 유틸을 추가하고 긴 변 기준으로 리사이즈/압축 처리
- 식품 등록/수정, 프로필 이미지 업로드 시 업로드 직전에 리사이즈 적용
- 리사이징 실패 시 원본 업로드로 fallback하여 업로드 안정성 확보

## 연관 이슈

- #123


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 음식 등록·수정 및 프로필 이미지 업로드 시 클라이언트 측 자동 이미지 리사이징 추가

* **개선사항**
  * 이미지가 최대 1280px로 압축되어 업로드되어 전송 효율 향상
  * 프로필 업로드 오류 처리 강화 및 서버오류 메시지 노출 개선으로 사용자 알림 신뢰성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->