### PR TITLE
Fix: 삭제 확인 모달 오픈 지연 개선

### DIFF
--- a/src/features/auth/screens/LoginScreen.tsx
+++ b/src/features/auth/screens/LoginScreen.tsx
@@ -134,7 +134,7 @@ export function LoginScreen() {
               h={rv({ sm: ms(48), md: ms(56), lg: ms(56) })}
               br="$3"
               fontWeight="700"
-              fontSize={rv({ sm: fs(14), md: fs(16), lg: fs(16) })}
+              fontSize={rv({ sm: fs(14), md: fs(15), lg: fs(16) })}
               icon={LogIn}
               pressStyle={{ opacity: 0.8, scale: 0.98 }}
               onPress={handleSubmit(handleLoginClick)}

--- a/src/features/home/components/FoodListItem/SwipeableFoodListItem.tsx
+++ b/src/features/home/components/FoodListItem/SwipeableFoodListItem.tsx
@@ -23,10 +23,12 @@ export function SwipeableFoodListItem({
           borderRadius="$4"
           disabled={isDeleting}
           onPress={() => {
-            swipeableRef.current?.close();
             if (onDelete) {
               onDelete(item.id);
             }
+            requestAnimationFrame(() => {
+              swipeableRef.current?.close();
+            });
           }}
           pressStyle={{ opacity: 0.7 }}
         >

--- a/src/features/home/screens/HomeScreen.tsx
+++ b/src/features/home/screens/HomeScreen.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/shared/stores/useFridgeStore";
 import { FlashList } from "@shopify/flash-list";
 import { useRouter } from "expo-router";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { View } from "react-native";
 import { Text, XStack, YStack } from "tamagui";
 import { CategoryTabs } from "../components/CategoryTabs";
@@ -61,6 +61,8 @@ export function HomeScreen() {
     ? allFoodStatusData
     : fridgeFoodStatusData;
 
+  const foodStatus = foodStatusData?.data;
+
   const isFoodLoading = isAllFridgeTab
     ? isAllFoodLoading
     : isRefrigeratorFoodLoading;
@@ -71,24 +73,26 @@ export function HomeScreen() {
   const [selectedCategory, setSelectedCategory] = useState("전체");
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
-  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
+  const deleteTargetRef = useRef<DeleteTarget | null>(null);
+  const [deletingFoodId, setDeletingFoodId] = useState<number | null>(null);
 
   const { mutate: deleteFood, isPending: isDeletePending } =
     useDeleteFoodMutation({
       onSettled: () => {
-        setDeleteTarget(null);
+        deleteTargetRef.current = null;
+        setDeletingFoodId(null);
       },
     });
 
   const allFoods = useMemo(() => {
-    if (!foodStatusData?.data) return [];
+    if (!foodStatus) return [];
     return [
-      ...foodStatusData.data.black,
-      ...foodStatusData.data.red,
-      ...foodStatusData.data.yellow,
-      ...foodStatusData.data.green,
+      ...foodStatus.black,
+      ...foodStatus.red,
+      ...foodStatus.yellow,
+      ...foodStatus.green,
     ];
-  }, [foodStatusData]);
+  }, [foodStatus]);
 
   const categoryOptions = useMemo(() => {
     const names = Array.from(
@@ -143,6 +147,54 @@ export function HomeScreen() {
     ? "전체"
     : fridgeData?.data?.find((f) => f.id === selectedFridgeId)?.name ||
       "냉장고";
+
+  const handleRequestDelete = useCallback(
+    (item: (typeof sortedAndFilteredFoods)[number]) => {
+      const targetFridgeId =
+        item.refrigeratorId || (!isAllFridgeTab ? selectedFridgeId : null);
+      if (!targetFridgeId) {
+        return;
+      }
+
+      deleteTargetRef.current = {
+        fridgeId: targetFridgeId,
+        foodId: item.id,
+        // foodName: item.name,
+      };
+      setIsDeleteConfirmOpen(true);
+    },
+    [isAllFridgeTab, selectedFridgeId],
+  );
+
+  const handlePressItem = useCallback(
+    (item: (typeof sortedAndFilteredFoods)[number]) => {
+      const targetRefrigeratorId =
+        item.refrigeratorId ?? selectedFridgeId ?? undefined;
+
+      router.push({
+        pathname: "/food/[id]",
+        params: {
+          id: item.id.toString(),
+          ...(targetRefrigeratorId !== undefined
+            ? { refrigeratorId: targetRefrigeratorId.toString() }
+            : {}),
+        },
+      } as any);
+    },
+    [router, selectedFridgeId],
+  );
+
+  const renderFoodItem = useCallback(
+    ({ item }: { item: (typeof sortedAndFilteredFoods)[number] }) => (
+      <SwipeableFoodListItem
+        item={item}
+        onDelete={() => handleRequestDelete(item)}
+        isDeleting={isDeletePending && deletingFoodId === item.id}
+        onPress={() => handlePressItem(item)}
+      />
+    ),
+    [deletingFoodId, handlePressItem, handleRequestDelete, isDeletePending],
+  );
 
   if (isFridgeLoading || isFoodLoading) {
     return (
@@ -199,41 +251,7 @@ export function HomeScreen() {
       <View style={{ flex: 1, width: "100%" }}>
         <FlashList
           data={sortedAndFilteredFoods}
-          renderItem={({ item }) => (
-            <SwipeableFoodListItem
-              item={item}
-              onDelete={() => {
-                const targetFridgeId =
-                  item.refrigeratorId ||
-                  (!isAllFridgeTab ? selectedFridgeId : null);
-                if (!targetFridgeId) {
-                  return;
-                }
-
-                setDeleteTarget({
-                  fridgeId: targetFridgeId,
-                  foodId: item.id,
-                  // foodName: item.name,
-                });
-                setIsDeleteConfirmOpen(true);
-              }}
-              isDeleting={isDeletePending && deleteTarget?.foodId === item.id}
-              onPress={() => {
-                const targetRefrigeratorId =
-                  item.refrigeratorId ?? selectedFridgeId ?? undefined;
-
-                router.push({
-                  pathname: "/food/[id]",
-                  params: {
-                    id: item.id.toString(),
-                    ...(targetRefrigeratorId !== undefined
-                      ? { refrigeratorId: targetRefrigeratorId.toString() }
-                      : {}),
-                  },
-                } as any);
-              }}
-            />
-          )}
+          renderItem={renderFoodItem}
           keyExtractor={(item) => item.id.toString()}
           //@ts-ignore
           contentContainerStyle={{ paddingBottom: ms(40) }}
@@ -260,19 +278,19 @@ export function HomeScreen() {
         }}
         title="정말 삭제하시겠습니까?"
         description={
-          deleteTarget
-            ? `삭제된 식품은 복구할 수 없습니다. 신중하게 선택해 주세요.`
-            : "선택한 식품을 삭제하시겠어요?"
+          `삭제된 식품은 복구할 수 없습니다. 신중하게 선택해 주세요.`
         }
         confirmText="삭제"
         onConfirm={() => {
-          if (!deleteTarget || isDeletePending) {
+          const target = deleteTargetRef.current;
+          if (!target || isDeletePending) {
             return;
           }
 
+          setDeletingFoodId(target.foodId);
           deleteFood({
-            fridgeId: deleteTarget.fridgeId,
-            foodId: deleteTarget.foodId,
+            fridgeId: target.fridgeId,
+            foodId: target.foodId,
           });
         }}
         confirmColor="$warning"

--- a/src/shared/components/Modal/ConfirmModal.tsx
+++ b/src/shared/components/Modal/ConfirmModal.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle } from "@tamagui/lucide-icons";
-import React from "react";
-import { Button, Dialog, Paragraph, Text, View, YStack } from "tamagui";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Animated, Modal, Pressable, StyleSheet } from "react-native";
+import { Button, Paragraph, Text, View, YStack } from "tamagui";
 import { ConfirmModalProps } from "./ConfirmModal.types";
 
 export const ConfirmModal = ({
@@ -14,94 +15,161 @@ export const ConfirmModal = ({
   closeOnConfirm = true,
   confirmDisabled = false,
 }: ConfirmModalProps) => {
+  const [rendered, setRendered] = useState(open);
+  const progress = useRef(new Animated.Value(open ? 1 : 0)).current;
+
+  useEffect(() => {
+    if (open) {
+      setRendered(true);
+      Animated.timing(progress, {
+        toValue: 1,
+        duration: 170,
+        useNativeDriver: true,
+      }).start();
+      return;
+    }
+
+    Animated.timing(progress, {
+      toValue: 0,
+      duration: 110,
+      useNativeDriver: true,
+    }).start(({ finished }) => {
+      if (finished) setRendered(false);
+    });
+  }, [open, progress]);
+
+  const overlayStyle = useMemo(
+    () => ({
+      opacity: progress.interpolate({
+        inputRange: [0, 1],
+        outputRange: [0, 1],
+      }),
+    }),
+    [progress],
+  );
+
+  const contentStyle = useMemo(
+    () => ({
+      opacity: progress.interpolate({
+        inputRange: [0, 1],
+        outputRange: [0, 1],
+      }),
+      transform: [
+        {
+          translateY: progress.interpolate({
+            inputRange: [0, 1],
+            outputRange: [8, 0],
+          }),
+        },
+        {
+          scale: progress.interpolate({
+            inputRange: [0, 1],
+            outputRange: [0.98, 1],
+          }),
+        },
+      ],
+    }),
+    [progress],
+  );
+
   return (
-    <Dialog modal open={open} onOpenChange={onOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Overlay
-          key="overlay"
-          animation="quick"
-          opacity={0.5}
-          enterStyle={{ opacity: 0 }}
-          exitStyle={{ opacity: 0 }}
-          backgroundColor="$black"
-        />
-        <Dialog.Content
-          bordered
-          elevate
-          key="content"
-          animation={[
-            "quick",
-            {
-              opacity: { overshootClamping: true },
-            },
-          ]}
-          enterStyle={{ x: 0, y: -20, opacity: 0, scale: 0.9 }}
-          exitStyle={{ x: 0, y: 10, opacity: 0, scale: 0.95 }}
-          x={0}
-          scale={1}
-          opacity={1}
-          width="85%"
-          maxWidth={400}
-          borderRadius="$5"
-          padding="$5"
-          backgroundColor="$background"
-        >
-          <YStack ai="center" gap="$3">
-            <View backgroundColor="$warningBackground" p="$4" br={100}>
-              <AlertTriangle size={40} color="$warning" />
-            </View>
+    <Modal
+      visible={rendered}
+      transparent
+      animationType="none"
+      onRequestClose={() => onOpenChange(false)}
+      statusBarTranslucent
+    >
+      <YStack f={1} jc="center" ai="center">
+        <Pressable style={styles.backdrop} onPress={() => onOpenChange(false)}>
+          <Animated.View style={[styles.overlay, overlayStyle]} />
+        </Pressable>
 
-            <YStack ai="center" gap="$2">
-              <Text
-                fontSize="$6"
-                fontWeight="700"
-                textAlign="center"
-                color="$mainText"
-                fontFamily="$baemin"
-              >
-                {title}
-              </Text>
-              <Paragraph
-                textAlign="center"
-                color="$gray10"
-                fontSize="$4"
-                lineHeight={22}
-                fontFamily="$baemin"
-              >
-                {description}
-              </Paragraph>
-            </YStack>
+        <Animated.View style={contentStyle}>
+          <YStack
+            key="confirm-modal"
+            width="80%"
+            maxWidth={360}
+            borderRadius="$5"
+            padding="$5"
+            backgroundColor="$background"
+            // 기존 Dialog의 bordered/elevate 느낌만 아주 약하게 유지
+            shadowColor="$black"
+            shadowOpacity={0.12}
+            shadowRadius={10}
+            shadowOffset={{ width: 0, height: 6 }}
+          >
+            <YStack ai="center" gap="$3">
+              <View backgroundColor="$warningBackground" p="$4" br={100}>
+                <AlertTriangle size={40} color="$warning" />
+              </View>
 
-            <YStack w="100%" gap="$2" mt="$2">
-              <Button
-                size="$5"
-                backgroundColor={confirmColor}
-                disabled={confirmDisabled}
-                onPress={() => {
-                  onConfirm();
-                  if (closeOnConfirm) {
-                    onOpenChange(false);
-                  }
-                }}
-                pressStyle={{ opacity: 0.8, scale: 0.98 }}
-                br="$2"
-              >
-                <Text color="$white" fontWeight="700" fontSize="$5">
-                  {confirmText}
+              <YStack ai="center" gap="$2">
+                <Text
+                  fontSize="$6"
+                  fontWeight="700"
+                  textAlign="center"
+                  color="$mainText"
+                  fontFamily="$baemin"
+                >
+                  {title}
                 </Text>
-              </Button>
+                <Paragraph
+                  textAlign="center"
+                  color="$gray10"
+                  fontSize="$4"
+                  lineHeight={22}
+                  fontFamily="$baemin"
+                >
+                  {description}
+                </Paragraph>
+              </YStack>
 
-              <Dialog.Close asChild>
-                <Button size="$5" backgroundColor="$gray3" chromeless br="$2">
+              <YStack w="100%" gap="$2" mt="$2">
+                <Button
+                  size="$5"
+                  backgroundColor={confirmColor}
+                  disabled={confirmDisabled}
+                  onPress={() => {
+                    onConfirm();
+                    if (closeOnConfirm) {
+                      onOpenChange(false);
+                    }
+                  }}
+                  pressStyle={{ opacity: 0.8, scale: 0.98 }}
+                  br="$2"
+                >
+                  <Text color="$white" fontWeight="700" fontSize="$5">
+                    {confirmText}
+                  </Text>
+                </Button>
+
+                <Button
+                  size="$5"
+                  backgroundColor="$gray3"
+                  chromeless
+                  br="$2"
+                  onPress={() => onOpenChange(false)}
+                >
                   <Text color="$mainText" fontWeight="700" fontSize="$5">
                     취소
                   </Text>
                 </Button>
-              </Dialog.Close>
+              </YStack>
             </YStack>
           </YStack>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog>
+        </Animated.View>
+      </YStack>
+    </Modal>
   );
 };
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  overlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.5)",
+  },
+});


### PR DESCRIPTION
## 작업 내용

- 홈 리스트에서 삭제 모달 오픈 시 불필요한 리렌더/연산을 줄여 반응성 개선
  - 삭제 타겟을 ref로 관리해 모달 오픈 시 리스트 리렌더 감소
  - FlashList renderItem/핸들러 메모이제이션
  - 스와이프 close를 다음 프레임으로 지연해 UI 반응성 개선
- 스와이프 닫기 작업을 다음 프레임으로 미뤄 모달 표시 체감 지연 완화
- ConfirmModal을 RN Modal + native Animated로 전환해 오픈 비용 감소(애니메이션 유지)
  - Dialog(Portal) 대신 RN Modal 사용으로 마운트 비용 감소

## 연관 이슈

- #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **스타일**
  * 로그인 버튼의 반응형 텍스트 크기를 조정했습니다.

* **버그 수정**
  * 삭제 작업의 애니메이션 성능을 개선했습니다.

* **리팩토링**
  * 모달 구성 요소의 애니메이션 및 상호작용을 개선하여 사용자 경험을 향상시켰습니다.
  * 삭제 상태 처리 메커니즘을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->