### PR TITLE
Perf: 카테고리 관련 바텀 시트 오픈 지연 개선

### DIFF
--- a/src/features/food-add/components/CategorySelector/CategoryActionSheet.tsx
+++ b/src/features/food-add/components/CategorySelector/CategoryActionSheet.tsx
@@ -23,11 +23,16 @@ export const CategoryActionSheet = ({
   const insets = useSafeAreaInsets();
   const { height: windowHeight } = useWindowDimensions();
 
+  const visibleRef = useRef(visible);
+  visibleRef.current = visible;
+
   const [show, setShow] = useState(false);
   const translateY = useRef(new Animated.Value(0)).current;
   const sheetOpacity = useRef(new Animated.Value(0)).current;
   const backdropOpacity = useRef(new Animated.Value(0)).current;
-  const isAnimatingRef = useRef(false);
+  const isEnterAnimatingRef = useRef(false);
+  const isExitAnimatingRef = useRef(false);
+  const pendingAfterCloseRef = useRef<(() => void) | null>(null);
   const hasOpenedRef = useRef(false);
 
   const sheetHiddenY = useMemo(
@@ -36,8 +41,8 @@ export const CategoryActionSheet = ({
   );
 
   const runClose = useCallback(() => {
-    if (isAnimatingRef.current) return;
-    isAnimatingRef.current = true;
+    if (isExitAnimatingRef.current) return;
+    isExitAnimatingRef.current = true;
 
     Animated.parallel([
       Animated.timing(backdropOpacity, {
@@ -59,8 +64,13 @@ export const CategoryActionSheet = ({
         useNativeDriver: true,
       }),
     ]).start(({ finished }) => {
-      isAnimatingRef.current = false;
-      if (finished) setShow(false);
+      isExitAnimatingRef.current = false;
+      if (finished) {
+        setShow(false);
+        const next = pendingAfterCloseRef.current;
+        pendingAfterCloseRef.current = null;
+        next?.();
+      }
     });
   }, [backdropOpacity, sheetHiddenY, sheetOpacity, translateY]);
 
@@ -69,7 +79,7 @@ export const CategoryActionSheet = ({
       hasOpenedRef.current = true;
       setShow(true);
       requestAnimationFrame(() => {
-        isAnimatingRef.current = true;
+        isEnterAnimatingRef.current = true;
         translateY.setValue(sheetHiddenY);
         sheetOpacity.setValue(0);
         backdropOpacity.setValue(0);
@@ -93,13 +103,19 @@ export const CategoryActionSheet = ({
             useNativeDriver: true,
           }),
         ]).start(() => {
-          isAnimatingRef.current = false;
+          isEnterAnimatingRef.current = false;
+          if (!visibleRef.current) {
+            runClose();
+          }
         });
       });
       return;
     }
 
     if (!hasOpenedRef.current) return;
+    if (isEnterAnimatingRef.current) {
+      return;
+    }
     runClose();
   }, [backdropOpacity, runClose, sheetHiddenY, sheetOpacity, translateY, visible]);
 
@@ -183,7 +199,7 @@ export const CategoryActionSheet = ({
                   br="$4"
                   onPress={() => {
                     if (!target) return;
-                    onEdit(target);
+                    pendingAfterCloseRef.current = () => onEdit(target);
                     onClose();
                   }}
                   pressStyle={{ scale: 0.97 }}
@@ -204,7 +220,7 @@ export const CategoryActionSheet = ({
                   br="$4"
                   onPress={() => {
                     if (!target) return;
-                    onDelete(target);
+                    pendingAfterCloseRef.current = () => onDelete(target);
                     onClose();
                   }}
                   pressStyle={{ scale: 0.97 }}

--- a/src/features/food-add/components/CategorySelector/CategoryActionSheet.tsx
+++ b/src/features/food-add/components/CategorySelector/CategoryActionSheet.tsx
@@ -1,7 +1,14 @@
-import React from "react";
-import { Modal, Pressable, StyleSheet } from "react-native";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Animated,
+  Easing,
+  Modal,
+  Pressable,
+  StyleSheet,
+  useWindowDimensions,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { AnimatePresence, Button, Text, View, XStack, YStack } from "tamagui";
+import { Button, Text, View, XStack, YStack } from "tamagui";
 import { CategoryActionSheetProps } from "../../types";
 import { getBottomPaddingForSheet, ms, s } from "@/shared/constants/layout";
 
@@ -14,136 +21,219 @@ export const CategoryActionSheet = ({
 }: CategoryActionSheetProps) => {
   const isDefaultType = Boolean(target?.isDefaultType);
   const insets = useSafeAreaInsets();
+  const { height: windowHeight } = useWindowDimensions();
+
+  const [show, setShow] = useState(false);
+  const translateY = useRef(new Animated.Value(0)).current;
+  const sheetOpacity = useRef(new Animated.Value(0)).current;
+  const backdropOpacity = useRef(new Animated.Value(0)).current;
+  const isAnimatingRef = useRef(false);
+  const hasOpenedRef = useRef(false);
+
+  const sheetHiddenY = useMemo(
+    () => Math.max(50, Math.round(windowHeight * 0.25)),
+    [windowHeight],
+  );
+
+  const runClose = useCallback(() => {
+    if (isAnimatingRef.current) return;
+    isAnimatingRef.current = true;
+
+    Animated.parallel([
+      Animated.timing(backdropOpacity, {
+        toValue: 0,
+        duration: 140,
+        easing: Easing.out(Easing.quad),
+        useNativeDriver: true,
+      }),
+      Animated.timing(sheetOpacity, {
+        toValue: 0,
+        duration: 140,
+        easing: Easing.out(Easing.quad),
+        useNativeDriver: true,
+      }),
+      Animated.timing(translateY, {
+        toValue: sheetHiddenY,
+        duration: 180,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }),
+    ]).start(({ finished }) => {
+      isAnimatingRef.current = false;
+      if (finished) setShow(false);
+    });
+  }, [backdropOpacity, sheetHiddenY, sheetOpacity, translateY]);
+
+  useEffect(() => {
+    if (visible) {
+      hasOpenedRef.current = true;
+      setShow(true);
+      requestAnimationFrame(() => {
+        isAnimatingRef.current = true;
+        translateY.setValue(sheetHiddenY);
+        sheetOpacity.setValue(0);
+        backdropOpacity.setValue(0);
+        Animated.parallel([
+          Animated.timing(backdropOpacity, {
+            toValue: 1,
+            duration: 160,
+            easing: Easing.out(Easing.quad),
+            useNativeDriver: true,
+          }),
+          Animated.timing(sheetOpacity, {
+            toValue: 1,
+            duration: 180,
+            easing: Easing.out(Easing.quad),
+            useNativeDriver: true,
+          }),
+          Animated.timing(translateY, {
+            toValue: 0,
+            duration: 220,
+            easing: Easing.out(Easing.cubic),
+            useNativeDriver: true,
+          }),
+        ]).start(() => {
+          isAnimatingRef.current = false;
+        });
+      });
+      return;
+    }
+
+    if (!hasOpenedRef.current) return;
+    runClose();
+  }, [backdropOpacity, runClose, sheetHiddenY, sheetOpacity, translateY, visible]);
 
   return (
     <Modal
-      visible={visible}
+      visible={show}
       transparent
       animationType="none"
       onRequestClose={onClose}
+      hardwareAccelerated
       statusBarTranslucent
     >
       <YStack f={1} jc="flex-end">
-        <Pressable style={styles.backdrop} onPress={onClose} />
+        <Pressable style={StyleSheet.absoluteFill} onPress={onClose}>
+          <Animated.View
+            style={[styles.backdrop, { opacity: backdropOpacity }]}
+          />
+        </Pressable>
 
-        <AnimatePresence>
-          {visible && (
-            <YStack
-              key="category-action-sheet"
-              bg="$background"
-              p="$5"
-              pb={getBottomPaddingForSheet({ bottomInset: insets.bottom })}
-              gap="$4"
-              br="$6"
-              borderBottomLeftRadius={0}
-              borderBottomRightRadius={0}
-              zIndex={100}
-              animation="quick"
-              enterStyle={{ y: 50, opacity: 0 }}
-              exitStyle={{ y: 50, opacity: 0 }}
-              y={0}
-              opacity={1}
-            >
-              <View
-                w={s(40)}
-                h={s(5)}
-                bg="$gray4"
-                br="$4"
-                alignSelf="center"
-                mb="$2"
-              />
+        <Animated.View
+          style={{
+            transform: [{ translateY }],
+            opacity: sheetOpacity,
+          }}
+        >
+          <YStack
+            bg="$background"
+            p="$5"
+            pb={getBottomPaddingForSheet({ bottomInset: insets.bottom })}
+            gap="$4"
+            br="$6"
+            borderBottomLeftRadius={0}
+            borderBottomRightRadius={0}
+            zIndex={100}
+          >
+            <View
+              w={s(40)}
+              h={s(5)}
+              bg="$gray4"
+              br="$4"
+              alignSelf="center"
+              mb="$2"
+            />
 
-              <YStack gap="$2" ai="center">
-                <Text fontSize="$5" fontWeight="700" fontFamily="$baemin">
-                  {target?.name ?? "카테고리"}
-                </Text>
-                <Text
-                  fontSize="$3"
-                  color="$gray10"
-                  textAlign="center"
-                  fontFamily="$baemin"
-                >
-                  {isDefaultType
-                    ? "기본 카테고리는 수정하거나 삭제할 수 없습니다."
-                    : "원하는 작업을 선택해주세요."}
-                </Text>
-              </YStack>
-
-              {isDefaultType ? (
-                <XStack>
-                  <Button
-                    flex={1}
-                    backgroundColor="$gray3"
-                    h={ms(48)}
-                    br="$4"
-                    onPress={onClose}
-                    pressStyle={{ scale: 0.97 }}
-                  >
-                    <Text color="$mainText" fontWeight="700" fontSize="$4">
-                      확인
-                    </Text>
-                  </Button>
-                </XStack>
-              ) : (
-                <YStack gap="$2">
-                  <Button
-                    backgroundColor="$primary"
-                    h={ms(48)}
-                    br="$4"
-                    onPress={() => {
-                      if (!target) return;
-                      onEdit(target);
-                      onClose();
-                    }}
-                    pressStyle={{ scale: 0.97 }}
-                  >
-                    <Text
-                      color="$mainText"
-                      fontWeight="700"
-                      fontSize="$4"
-                      fontFamily="$baemin"
-                    >
-                      이름 수정
-                    </Text>
-                  </Button>
-
-                  <Button
-                    backgroundColor="$warning"
-                    h={ms(48)}
-                    br="$4"
-                    onPress={() => {
-                      if (!target) return;
-                      onDelete(target);
-                      onClose();
-                    }}
-                    pressStyle={{ scale: 0.97 }}
-                  >
-                    <Text color="$white" fontWeight="700" fontSize="$4">
-                      삭제
-                    </Text>
-                  </Button>
-
-                  <Button
-                    backgroundColor="$gray3"
-                    h={ms(48)}
-                    br="$4"
-                    onPress={onClose}
-                    pressStyle={{ scale: 0.97 }}
-                  >
-                    <Text
-                      color="$mainText"
-                      fontWeight="700"
-                      fontSize="$4"
-                      fontFamily="$baemin"
-                    >
-                      취소
-                    </Text>
-                  </Button>
-                </YStack>
-              )}
+            <YStack gap="$2" ai="center">
+              <Text fontSize="$5" fontWeight="700" fontFamily="$baemin">
+                {target?.name ?? "카테고리"}
+              </Text>
+              <Text
+                fontSize="$3"
+                color="$gray10"
+                textAlign="center"
+                fontFamily="$baemin"
+              >
+                {isDefaultType
+                  ? "기본 카테고리는 수정하거나 삭제할 수 없습니다."
+                  : "원하는 작업을 선택해주세요."}
+              </Text>
             </YStack>
-          )}
-        </AnimatePresence>
+
+            {isDefaultType ? (
+              <XStack>
+                <Button
+                  flex={1}
+                  backgroundColor="$gray3"
+                  h={ms(48)}
+                  br="$4"
+                  onPress={onClose}
+                  pressStyle={{ scale: 0.97 }}
+                >
+                  <Text color="$mainText" fontWeight="700" fontSize="$4">
+                    확인
+                  </Text>
+                </Button>
+              </XStack>
+            ) : (
+              <YStack gap="$2">
+                <Button
+                  backgroundColor="$primary"
+                  h={ms(48)}
+                  br="$4"
+                  onPress={() => {
+                    if (!target) return;
+                    onEdit(target);
+                    onClose();
+                  }}
+                  pressStyle={{ scale: 0.97 }}
+                >
+                  <Text
+                    color="$mainText"
+                    fontWeight="700"
+                    fontSize="$4"
+                    fontFamily="$baemin"
+                  >
+                    이름 수정
+                  </Text>
+                </Button>
+
+                <Button
+                  backgroundColor="$warning"
+                  h={ms(48)}
+                  br="$4"
+                  onPress={() => {
+                    if (!target) return;
+                    onDelete(target);
+                    onClose();
+                  }}
+                  pressStyle={{ scale: 0.97 }}
+                >
+                  <Text color="$white" fontWeight="700" fontSize="$4">
+                    삭제
+                  </Text>
+                </Button>
+
+                <Button
+                  backgroundColor="$gray3"
+                  h={ms(48)}
+                  br="$4"
+                  onPress={onClose}
+                  pressStyle={{ scale: 0.97 }}
+                >
+                  <Text
+                    color="$mainText"
+                    fontWeight="700"
+                    fontSize="$4"
+                    fontFamily="$baemin"
+                  >
+                    취소
+                  </Text>
+                </Button>
+              </YStack>
+            )}
+          </YStack>
+        </Animated.View>
       </YStack>
     </Modal>
   );
@@ -155,4 +245,3 @@ const styles = StyleSheet.create({
     backgroundColor: "rgba(0,0,0,0.5)",
   },
 });
-

--- a/src/features/food-add/components/CategorySelector/CategoryFormSheet.tsx
+++ b/src/features/food-add/components/CategorySelector/CategoryFormSheet.tsx
@@ -1,24 +1,21 @@
 import { getBottomPaddingForSheet, ms, s } from "@/shared/constants/layout";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import {
+  Animated,
+  Easing,
+  InteractionManager,
   Keyboard,
   KeyboardAvoidingView,
   Modal,
   Platform,
   Pressable,
   StyleSheet,
+  TextInput,
+  useWindowDimensions,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import {
-  AnimatePresence,
-  Button,
-  Input,
-  Text,
-  View,
-  XStack,
-  YStack,
-} from "tamagui";
+import { Button, Input, Text, View, XStack, YStack } from "tamagui";
 import { CategoryFormSheetProps, CategoryFormValues } from "../../types";
 
 export const CategoryFormSheet = ({
@@ -32,6 +29,20 @@ export const CategoryFormSheet = ({
   const isEditMode = Boolean(editTarget);
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
   const insets = useSafeAreaInsets();
+  const { height: windowHeight } = useWindowDimensions();
+  const nameInputRef = useRef<TextInput | null>(null);
+
+  const [show, setShow] = useState(false);
+  const translateY = useRef(new Animated.Value(0)).current;
+  const sheetOpacity = useRef(new Animated.Value(0)).current;
+  const backdropOpacity = useRef(new Animated.Value(0)).current;
+  const isAnimatingRef = useRef(false);
+  const hasOpenedRef = useRef(false);
+
+  const sheetHiddenY = useMemo(
+    () => Math.max(50, Math.round(windowHeight * 0.25)),
+    [windowHeight],
+  );
 
   const {
     control,
@@ -66,6 +77,82 @@ export const CategoryFormSheet = ({
     };
   }, []);
 
+  const runClose = useCallback(() => {
+    if (isAnimatingRef.current) return;
+    isAnimatingRef.current = true;
+
+    Animated.parallel([
+      Animated.timing(backdropOpacity, {
+        toValue: 0,
+        duration: 140,
+        easing: Easing.out(Easing.quad),
+        useNativeDriver: true,
+      }),
+      Animated.timing(sheetOpacity, {
+        toValue: 0,
+        duration: 140,
+        easing: Easing.out(Easing.quad),
+        useNativeDriver: true,
+      }),
+      Animated.timing(translateY, {
+        toValue: sheetHiddenY,
+        duration: 180,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }),
+    ]).start(({ finished }) => {
+      isAnimatingRef.current = false;
+      if (finished) setShow(false);
+    });
+  }, [backdropOpacity, sheetHiddenY, sheetOpacity, translateY]);
+
+  useEffect(() => {
+    if (visible) {
+      hasOpenedRef.current = true;
+      setShow(true);
+      requestAnimationFrame(() => {
+        isAnimatingRef.current = true;
+        translateY.setValue(sheetHiddenY);
+        sheetOpacity.setValue(0);
+        backdropOpacity.setValue(0);
+        Animated.parallel([
+          Animated.timing(backdropOpacity, {
+            toValue: 1,
+            duration: 160,
+            easing: Easing.out(Easing.quad),
+            useNativeDriver: true,
+          }),
+          Animated.timing(sheetOpacity, {
+            toValue: 1,
+            duration: 180,
+            easing: Easing.out(Easing.quad),
+            useNativeDriver: true,
+          }),
+          Animated.timing(translateY, {
+            toValue: 0,
+            duration: 220,
+            easing: Easing.out(Easing.cubic),
+            useNativeDriver: true,
+          }),
+        ]).start(() => {
+          isAnimatingRef.current = false;
+        });
+      });
+      return;
+    }
+
+    if (!hasOpenedRef.current) return;
+    runClose();
+  }, [backdropOpacity, runClose, sheetHiddenY, sheetOpacity, translateY, visible]);
+
+  useEffect(() => {
+    if (!visible || !show || isEditMode) return;
+    const task = InteractionManager.runAfterInteractions(() => {
+      nameInputRef.current?.focus();
+    });
+    return () => task.cancel();
+  }, [visible, show, isEditMode]);
+
   const onSubmit = async ({ name }: CategoryFormValues) => {
     if (isPending) return;
 
@@ -88,10 +175,11 @@ export const CategoryFormSheet = ({
 
   return (
     <Modal
-      visible={visible}
+      visible={show}
       transparent
       animationType="none"
       onRequestClose={onClose}
+      hardwareAccelerated
       statusBarTranslucent
     >
       <KeyboardAvoidingView
@@ -107,98 +195,99 @@ export const CategoryFormSheet = ({
       >
         <YStack f={1} jc="flex-end">
           <Pressable
-            style={styles.backdrop}
+            style={StyleSheet.absoluteFill}
             onPress={() => {
               Keyboard.dismiss();
               onClose();
             }}
-          />
+          >
+            <Animated.View
+              style={[styles.backdrop, { opacity: backdropOpacity }]}
+            />
+          </Pressable>
 
-          <AnimatePresence>
-            {visible && (
-              <YStack
-                key="category-form-sheet"
-                bg="$background"
-                p="$5"
-                pb={getBottomPaddingForSheet({ bottomInset: insets.bottom })}
-                gap="$4"
-                br="$6"
-                borderBottomLeftRadius={0}
-                borderBottomRightRadius={0}
-                zIndex={100}
-                animation="quick"
-                enterStyle={{ y: 50, opacity: 0 }}
-                exitStyle={{ y: 50, opacity: 0 }}
-                y={0}
-                opacity={1}
-              >
-                <View
-                  w={s(40)}
-                  h={s(5)}
-                  bg="$gray4"
-                  br="$4"
-                  alignSelf="center"
-                  mb="$2"
-                />
+          <Animated.View
+            style={{
+              transform: [{ translateY }],
+              opacity: sheetOpacity,
+            }}
+          >
+            <YStack
+              bg="$background"
+              p="$5"
+              pb={getBottomPaddingForSheet({ bottomInset: insets.bottom })}
+              gap="$4"
+              br="$6"
+              borderBottomLeftRadius={0}
+              borderBottomRightRadius={0}
+              zIndex={100}
+            >
+              <View
+                w={s(40)}
+                h={s(5)}
+                bg="$gray4"
+                br="$4"
+                alignSelf="center"
+                mb="$2"
+              />
 
-                <Text fontSize="$5" fontWeight="700" fontFamily="$baemin">
-                  {isEditMode ? "카테고리 수정" : "카테고리 추가"}
-                </Text>
+              <Text fontSize="$5" fontWeight="700" fontFamily="$baemin">
+                {isEditMode ? "카테고리 수정" : "카테고리 추가"}
+              </Text>
 
-                <YStack gap="$2">
-                  <Controller
-                    control={control}
-                    name="name"
-                    rules={{
-                      required: "이름을 입력해주세요.",
-                      validate: (v) =>
-                        v.trim().length > 0 || "공백은 입력할 수 없습니다.",
-                    }}
-                    render={({ field: { onChange, value } }) => (
-                      <Input
-                        autoFocus={!isEditMode}
-                        h={ms(48)}
-                        placeholder={
-                          isEditMode ? "카테고리 이름" : "새 카테고리 이름"
-                        }
-                        value={value}
-                        onChangeText={onChange}
-                        backgroundColor="$gray3"
-                        br="$4"
-                        bw={errors.name ? 1 : 0}
-                        boc="$warning"
-                        fontSize="$2"
-                        fontFamily="$baemin"
-                        onSubmitEditing={handleSubmit(onSubmit)}
-                        returnKeyType="done"
-                      />
-                    )}
-                  />
-                </YStack>
-
-                <XStack>
-                  <Button
-                    flex={1}
-                    backgroundColor="$primary"
-                    h={ms(48)}
-                    br="$4"
-                    onPress={handleSubmit(onSubmit)}
-                    disabled={isPending}
-                    pressStyle={{ scale: 0.97 }}
-                  >
-                    <Text
-                      color="$mainText"
-                      fontWeight="700"
-                      fontSize="$4"
+              <YStack gap="$2">
+                <Controller
+                  control={control}
+                  name="name"
+                  rules={{
+                    required: "이름을 입력해주세요.",
+                    validate: (v) =>
+                      v.trim().length > 0 || "공백은 입력할 수 없습니다.",
+                  }}
+                  render={({ field: { onChange, value } }) => (
+                    <Input
+                      ref={nameInputRef}
+                      h={ms(48)}
+                      placeholder={
+                        isEditMode ? "카테고리 이름" : "새 카테고리 이름"
+                      }
+                      value={value}
+                      onChangeText={onChange}
+                      backgroundColor="$gray3"
+                      br="$4"
+                      bw={errors.name ? 1 : 0}
+                      boc="$warning"
+                      fontSize="$2"
                       fontFamily="$baemin"
-                    >
-                      {isEditMode ? "저장하기" : "추가하기"}
-                    </Text>
-                  </Button>
-                </XStack>
+                      onSubmitEditing={handleSubmit(onSubmit)}
+                      returnKeyType="done"
+                    />
+                  )}
+                />
               </YStack>
-            )}
-          </AnimatePresence>
+
+              <XStack>
+                <Button
+                  flex={1}
+                  backgroundColor="$primary"
+                  h={ms(48)}
+                  br="$4"
+                  onPress={handleSubmit(onSubmit)}
+                  disabled={isPending}
+                  pressStyle={{ scale: 0.97 }}
+                >
+                  <Text
+                    color="$mainText"
+                    fontWeight="700"
+                    fontSize="$4"
+                    fontFamily="$baemin"
+                  >
+                    {isEditMode ? "저장하기" : "추가하기"}
+                  </Text>
+                </Button>
+              </XStack>
+            </YStack>
+          </Animated.View>
         </YStack>
       </KeyboardAvoidingView>
     </Modal>

--- a/src/features/food-add/components/CategorySelector/CategoryFormSheet.tsx
+++ b/src/features/food-add/components/CategorySelector/CategoryFormSheet.tsx
@@ -32,11 +32,15 @@ export const CategoryFormSheet = ({
   const { height: windowHeight } = useWindowDimensions();
   const nameInputRef = useRef<TextInput | null>(null);
 
+  const visibleRef = useRef(visible);
+  visibleRef.current = visible;
+
   const [show, setShow] = useState(false);
   const translateY = useRef(new Animated.Value(0)).current;
   const sheetOpacity = useRef(new Animated.Value(0)).current;
   const backdropOpacity = useRef(new Animated.Value(0)).current;
-  const isAnimatingRef = useRef(false);
+  const isEnterAnimatingRef = useRef(false);
+  const isExitAnimatingRef = useRef(false);
   const hasOpenedRef = useRef(false);
 
   const sheetHiddenY = useMemo(
@@ -78,8 +82,8 @@ export const CategoryFormSheet = ({
   }, []);
 
   const runClose = useCallback(() => {
-    if (isAnimatingRef.current) return;
-    isAnimatingRef.current = true;
+    if (isExitAnimatingRef.current) return;
+    isExitAnimatingRef.current = true;
 
     Animated.parallel([
       Animated.timing(backdropOpacity, {
@@ -101,7 +105,7 @@ export const CategoryFormSheet = ({
         useNativeDriver: true,
       }),
     ]).start(({ finished }) => {
-      isAnimatingRef.current = false;
+      isExitAnimatingRef.current = false;
       if (finished) setShow(false);
     });
   }, [backdropOpacity, sheetHiddenY, sheetOpacity, translateY]);
@@ -111,7 +115,7 @@ export const CategoryFormSheet = ({
       hasOpenedRef.current = true;
       setShow(true);
       requestAnimationFrame(() => {
-        isAnimatingRef.current = true;
+        isEnterAnimatingRef.current = true;
         translateY.setValue(sheetHiddenY);
         sheetOpacity.setValue(0);
         backdropOpacity.setValue(0);
@@ -135,13 +139,19 @@ export const CategoryFormSheet = ({
             useNativeDriver: true,
           }),
         ]).start(() => {
-          isAnimatingRef.current = false;
+          isEnterAnimatingRef.current = false;
+          if (!visibleRef.current) {
+            runClose();
+          }
         });
       });
       return;
     }
 
     if (!hasOpenedRef.current) return;
+    if (isEnterAnimatingRef.current) {
+      return;
+    }
     runClose();
   }, [backdropOpacity, runClose, sheetHiddenY, sheetOpacity, translateY, visible]);
 


### PR DESCRIPTION
## 작업 내용

- Tamagui 기반 시트 등장 애니메이션을 제거하고, RN Animated로 배경 딤 + 시트 슬라이드를 처리
- 닫을 때는 닫힘 애니메이션 종료 후 Modal을 숨겨, 불필요한 마운트·레이아웃 비용을 줄임
- CategoryFormSheet에서  추가 모드에서 입력 포커스를 트랜지션 이후로 미뤄, 키보드와 시트 애니메이션이 겹치는 구간의 끊김 완화

## 연관 이슈

- #127


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 카테고리 시트(선택/편집)의 전환 애니메이션이 더 부드럽고 일관되게 동작하도록 개선
  * 모달 백드롭 및 닫힘 동작이 최적화되어 화면 전환이 자연스러워짐
  * 이름 입력 필드 포커스가 더 안정적으로 작동하여 편집 경험이 향상됨
* **Bug Fixes**
  * 편집/삭제 동작이 닫힘 애니메이션 후에 적용되어 예기치 않은 동작 감소
<!-- end of auto-generated comment: release notes by coderabbit.ai -->