### PR TITLE
Chore: 알림설정 페이지 뒤로가기 라우팅 수정

### DIFF
--- a/src/features/notification/screens/NotificationSettingScreen.tsx
+++ b/src/features/notification/screens/NotificationSettingScreen.tsx
@@ -1,5 +1,8 @@
 import { Bell, Clock, Info, Users } from "@tamagui/lucide-icons";
+import { useFocusEffect } from "@react-navigation/native";
+import { useRouter } from "expo-router";
 import React, { useCallback, useMemo } from "react";
+import { BackHandler } from "react-native";
 import Toast from "react-native-toast-message";
 import {
   Button,
@@ -20,12 +23,27 @@ import { TimePickerSelect } from "../components/TimePicker/TimePickerSelect";
 import { useNotificationSettings } from "../hooks/useNotificationSettings";
 
 export function NotificationSettingScreen() {
+  const router = useRouter();
   const {
     data: settings,
     isLoading,
     updateSettings,
     isUpdating,
   } = useNotificationSettings();
+
+  const goBackToProfile = useCallback(() => {
+    router.replace("/profile");
+  }, [router]);
+
+  useFocusEffect(
+    useCallback(() => {
+      const sub = BackHandler.addEventListener("hardwareBackPress", () => {
+        goBackToProfile();
+        return true;
+      });
+      return () => sub.remove();
+    }, [goBackToProfile]),
+  );
 
   const handleOpenNotificationSettings = useCallback(async () => {
     try {
@@ -64,7 +82,12 @@ export function NotificationSettingScreen() {
   if (isLoading || !settings) {
     return (
       <YStack f={1} backgroundColor="$background">
-        <Header title="알림" showBackButton showNotificationBell={false} />
+        <Header
+          title="알림"
+          showBackButton
+          showNotificationBell={false}
+          onBackPress={goBackToProfile}
+        />
         <YStack f={1} jc="center" ai="center">
           <Spinner size="large" color="$primary" />
         </YStack>
@@ -74,7 +97,12 @@ export function NotificationSettingScreen() {
 
   return (
     <YStack f={1} backgroundColor="$background">
-      <Header title="알림 설정" showBackButton showNotificationBell={false} />
+      <Header
+        title="알림 설정"
+        showBackButton
+        showNotificationBell={false}
+        onBackPress={goBackToProfile}
+      />
 
       <ScrollView f={1}>
         <YStack gap="$5">

--- a/src/shared/components/Header/Header.tsx
+++ b/src/shared/components/Header/Header.tsx
@@ -10,6 +10,7 @@ export function Header({
   title = "Fridgely",
   showBackButton = false,
   showNotificationBell = false,
+  onBackPress,
 }: HeaderProps) {
   const insets = useSafeAreaInsets();
   const router = useRouter();
@@ -32,7 +33,9 @@ export function Header({
               size="$2"
               chromeless
               icon={<ChevronLeft size={s(22)} color="$mainText" />}
-              onPress={() => router.back()}
+              onPress={() =>
+                onBackPress ? onBackPress() : router.back()
+              }
               paddingLeft={0}
             />
           ) : (

--- a/src/shared/components/Header/Header.types.ts
+++ b/src/shared/components/Header/Header.types.ts
@@ -2,6 +2,8 @@ interface HeaderProps {
   title?: string;
   showBackButton?: boolean;
   showNotificationBell?: boolean;
+  /** 있으면 뒤로 버튼에서 `router.back()` 대신 실행 */
+  onBackPress?: () => void;
 }
 
 export { HeaderProps };


### PR DESCRIPTION
## 작업 내용

- 알림설정 페이지에서 뒤로가기 시 홈으로 가던 라우터를 마이페이지로 가도록 수정

## 연관 이슈

- #131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 알림 설정 화면에서 뒤로가기 버튼 동작이 개선되었습니다.
  * 헤더 컴포넌트의 뒤로가기 버튼이 더욱 유연하게 작동하도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->