### PR TITLE
Fix: 디바이스 토큰 동기화  중복 호출 방지

### DIFF
--- a/src/shared/lib/fcm/useFcmSync.ts
+++ b/src/shared/lib/fcm/useFcmSync.ts
@@ -1,50 +1,58 @@
 import { getMessaging, onTokenRefresh } from "@react-native-firebase/messaging";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { AppState, AppStateStatus } from "react-native";
 import { getFcmToken } from "./getFcmToken";
+
+let fcmSyncTail = Promise.resolve();
+
+let lastSyncedPair: { userId: string; token: string } | null = null;
 
 export const useFcmSync = (
   userId: string | null,
   onSync?: (token: string) => Promise<void>,
 ) => {
   const appState = useRef<AppStateStatus>(AppState.currentState);
-  const lastSyncRef = useRef<{ token: string; userId: string | null }>({
-    token: "",
-    userId: null,
-  });
+  const onSyncRef = useRef(onSync);
+  onSyncRef.current = onSync;
 
-  const syncFcmToken = async (currentUserId: string | null) => {
+  const syncFcmToken = useCallback(async (currentUserId: string | null) => {
     if (!currentUserId) {
-      // 사용자 미로그인 상태
+      lastSyncedPair = null;
       return;
     }
 
-    try {
-      const fcmToken = await getFcmToken();
-      if (!fcmToken) {
-        console.warn("FCM: 토큰을 찾을 수 없음");
-        return;
-      }
+    const run = async () => {
+      try {
+        const fcmToken = await getFcmToken();
+        if (!fcmToken) {
+          console.warn("FCM: 토큰을 찾을 수 없음");
+          return;
+        }
 
-      const prevToken = lastSyncRef.current.token;
-      const prevUserId = lastSyncRef.current.userId;
+        if (
+          lastSyncedPair?.userId === currentUserId &&
+          lastSyncedPair?.token === fcmToken
+        ) {
+          return;
+        }
 
-      if (fcmToken !== prevToken || currentUserId !== prevUserId) {
-        if (onSync) await onSync(fcmToken);
-        // 토큰 또는 사용자 ID가 변경된 경우에만 서버에 동기화
-        lastSyncRef.current = { token: fcmToken, userId: currentUserId };
-      } else {
-        // 토큰과 사용자 ID 모두 변경되지 않음
+        const register = onSyncRef.current;
+        if (register) await register(fcmToken);
+        lastSyncedPair = { userId: currentUserId, token: fcmToken };
+      } catch (error) {
+        console.error("FCM 토큰 동기화 실패:", error);
       }
-    } catch (error) {
-      // 동기화 실패 시에도 앱이 정상 동작하도록 에러를 무시
+    };
+
+    fcmSyncTail = fcmSyncTail.then(run).catch((error) => {
       console.error("FCM 토큰 동기화 실패:", error);
-    }
-  };
+    });
+    await fcmSyncTail;
+  }, []);
 
   useEffect(() => {
     syncFcmToken(userId);
-  }, [userId]);
+  }, [userId, syncFcmToken]);
 
   useEffect(() => {
     // 토큰 갱신
@@ -53,7 +61,7 @@ export const useFcmSync = (
       syncFcmToken(userId);
     });
     return unsubscribe;
-  }, [userId]);
+  }, [userId, syncFcmToken]);
 
   useEffect(() => {
     // 앱이 포그라운드로 돌아올 때 토큰 동기화
@@ -71,5 +79,5 @@ export const useFcmSync = (
       },
     );
     return () => subscription.remove();
-  }, [userId]);
+  }, [userId, syncFcmToken]);
 };


### PR DESCRIPTION
## 작업 내용

- useFcmSync에 모듈 스코프 단일 Promise 체인(fcmSyncTail)으로 전역 직렬화.
- 모듈 스코프 lastSyncedPair로 동일 userId + FCM token이면 onSync(PUT) 생략.
- userId === null(로그아웃) 시 lastSyncedPair 초기화 → 재로그인 시 정상 재동기화.
- onSync는 useRef로 최신 콜백 유지, syncFcmToken은 useCallback으로 effect 의존성 정리.
## 연관 이슈

- #133
