### PR TITLE
Fix: 로그아웃 후 불필요한 프로필 조회 방지

### DIFF
--- a/src/features/profile/__tests__/hooks/useMemberProfileQuery.test.tsx
+++ b/src/features/profile/__tests__/hooks/useMemberProfileQuery.test.tsx
@@ -4,6 +4,10 @@ import { renderHook, waitFor } from "@testing-library/react-native";
 import React from "react";
 import { useMemberProfileQuery } from "../../hooks/queries/useMemberProfileQuery";
 
+jest.mock("@/features/auth/store/useAuthStore", () => ({
+  useIsLoggedIn: () => true,
+}));
+
 jest.mock("@/shared/apis/apiClient");
 const mockedApiClient = apiClient as jest.MockedFunction<typeof apiClient>;
 

--- a/src/features/profile/hooks/queries/useMemberProfileQuery.ts
+++ b/src/features/profile/hooks/queries/useMemberProfileQuery.ts
@@ -1,9 +1,14 @@
+import { useIsLoggedIn } from "@/features/auth/store/useAuthStore";
 import { useApiQuery } from "@/shared/apis/builder/ApiBuilder";
 import { QUERY_KEYS } from "@/shared/constants/queryKeys";
 import { getMemberProfileApi } from "../../apis/profile";
 
 const useMemberProfileQuery = () => {
-  return useApiQuery(getMemberProfileApi, QUERY_KEYS.member.me());
+  const isLoggedIn = useIsLoggedIn();
+
+  return useApiQuery(getMemberProfileApi, QUERY_KEYS.member.me(), {
+    enabled: isLoggedIn,
+  });
 };
 
 export { useMemberProfileQuery };

--- a/src/features/profile/hooks/useLogoutMutation.ts
+++ b/src/features/profile/hooks/useLogoutMutation.ts
@@ -1,13 +1,18 @@
 import { useAuthActions } from "@/features/auth/store/useAuthStore";
 import { useApiMutation } from "@/shared/apis/builder/ApiBuilder";
+import { QUERY_KEYS } from "@/shared/constants/queryKeys";
+import { useQueryClient } from "@tanstack/react-query";
 import Toast from "react-native-toast-message";
 import { logoutApi } from "../apis/profile";
 
 const useLogoutMutation = () => {
   const { logout } = useAuthActions();
+  const queryClient = useQueryClient();
 
   return useApiMutation<void, void>(logoutApi, {
     onSuccess: async () => {
+      await queryClient.cancelQueries({ queryKey: QUERY_KEYS.member.me() });
+      queryClient.removeQueries({ queryKey: QUERY_KEYS.member.me() });
       await logout();
       Toast.show({
         type: "success",
@@ -17,6 +22,8 @@ const useLogoutMutation = () => {
     },
     onError: async (error: any) => {
       if (error.response?.status === 401) {
+        await queryClient.cancelQueries({ queryKey: QUERY_KEYS.member.me() });
+        queryClient.removeQueries({ queryKey: QUERY_KEYS.member.me() });
         await logout();
         Toast.show({
           type: "success",


### PR DESCRIPTION
## 작업 내용

- 로그아웃 뒤에도 프로필 조회 쿼리가 돌아가서 401이 났음 → 로그인할 때만 프로필 쿼리 켜지게 변경
- 로그아웃 시 해당 쿼리 지우도록 처리함

## 연관 이슈

- #133
