### PR TITLE
Feat: 캘린더페이지 연,월 선택 피커 추가

### DIFF
--- a/src/features/calendar/components/CalendarMonthView.tsx
+++ b/src/features/calendar/components/CalendarMonthView.tsx
@@ -1,8 +1,10 @@
 import { getCalendarTheme } from "@/features/calendar/constants/calendarTheme";
+import { CalendarMonthYearPickerModal } from "@/features/calendar/components/CalendarMonthYearPickerModal";
+import { daysInMonth, pad2 } from "@/features/calendar/utils/calendar";
 import { fs, ms, rv, s } from "@/shared/constants/layout";
 import { resolveTheme, useThemeStore } from "@/shared/stores/useThemeStore";
 import { ChevronLeft, ChevronRight } from "@tamagui/lucide-icons";
-import React from "react";
+import React, { useCallback, useState } from "react";
 import {
   Pressable,
   Text as RNText,
@@ -29,9 +31,35 @@ export function CalendarMonthView({
   const selectedDayTextColor = "#111111";
   const disabledDayTextColor = isDark ? "#4A5A56" : "#D0D4D3";
 
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerSeed, setPickerSeed] = useState({ y: 0, m: 1 });
+  const [jumpKey, setJumpKey] = useState(0);
+
+  const openMonthYearPicker = useCallback(
+    (month: { getFullYear(): number; getMonth(): number }) => {
+      setPickerSeed({ y: month.getFullYear(), m: month.getMonth() + 1 });
+      setPickerOpen(true);
+    },
+    [],
+  );
+
+  const applyMonthYear = useCallback(
+    (year: number, month: number) => {
+      const maxDay = daysInMonth(year, month);
+      const parts = selectedDate.split("-").map(Number);
+      const prevDay = parts[2] ?? 1;
+      const day = Math.min(prevDay, maxDay);
+      onSelectDate(`${year}-${pad2(month)}-${pad2(day)}`);
+      setJumpKey((k) => k + 1);
+      setPickerOpen(false);
+    },
+    [onSelectDate, selectedDate],
+  );
+
   return (
     <View px="$2">
       <Calendar
+        key={jumpKey}
         current={selectedDate}
         onDayPress={(day: DateData) => onSelectDate(day.dateString)}
         markingType="multi-dot"
@@ -47,6 +75,21 @@ export function CalendarMonthView({
               <ChevronRight size={s(22)} color="$mainText" />
             )}
           </RNText>
+        )}
+        renderHeader={(month) => (
+          <Pressable
+            onPress={() => openMonthYearPicker(month)}
+            accessibilityRole="button"
+            accessibilityLabel="연도 및 월 선택"
+            hitSlop={12}
+          >
+            <RNText
+              style={[styles.headerTitle, { color: arrowColor }]}
+              numberOfLines={1}
+            >
+              {`${month.getFullYear()}년 ${month.getMonth() + 1}월`}
+            </RNText>
+          </Pressable>
         )}
         dayComponent={({ date, state, marking, onPress }) => {
           const isSelected = !!marking?.selected;
@@ -95,11 +138,25 @@ export function CalendarMonthView({
           );
         }}
       />
+
+      <CalendarMonthYearPickerModal
+        open={pickerOpen}
+        year={pickerSeed.y}
+        month={pickerSeed.m}
+        onClose={() => setPickerOpen(false)}
+        onConfirm={applyMonthYear}
+      />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
+  headerTitle: {
+    fontFamily: "BMJUA",
+    fontSize: rv({ sm: fs(16), md: fs(18), lg: fs(18) }),
+    fontWeight: "700",
+    textAlign: "center",
+  },
   arrow: {
     fontSize: rv({ sm: fs(14), md: fs(18), lg: fs(18) }),
     fontWeight: "700",

--- a/src/features/calendar/components/CalendarMonthYearPickerModal.tsx
+++ b/src/features/calendar/components/CalendarMonthYearPickerModal.tsx
@@ -1,0 +1,232 @@
+import { fs, ms, rv } from "@/shared/constants/layout";
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  Modal,
+  Pressable,
+  Text as RNText,
+  View as RNView,
+  ScrollView,
+  StyleSheet,
+} from "react-native";
+import { Button, Text, YStack } from "tamagui";
+
+type CalendarMonthYearPickerModalProps = {
+  open: boolean;
+  year: number;
+  month: number;
+  onClose: () => void;
+  onConfirm: (year: number, month: number) => void;
+};
+
+const MONTHS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+const MIN_SELECTABLE_YEAR = 2026;
+
+export function CalendarMonthYearPickerModal({
+  open,
+  year,
+  month,
+  onClose,
+  onConfirm,
+}: CalendarMonthYearPickerModalProps) {
+  const [draftYear, setDraftYear] = useState(year);
+  const [draftMonth, setDraftMonth] = useState(month);
+
+  useEffect(() => {
+    if (open) {
+      setDraftYear(Math.max(year, MIN_SELECTABLE_YEAR));
+      setDraftMonth(month);
+    }
+  }, [open, year, month]);
+
+  const yearRange = useMemo(() => {
+    const lastYear = Math.max(
+      MIN_SELECTABLE_YEAR + 12,
+      new Date().getFullYear() + 8,
+    );
+    const list: number[] = [];
+    for (let i = MIN_SELECTABLE_YEAR; i <= lastYear; i += 1) {
+      list.push(i);
+    }
+    return list;
+  }, []);
+
+  return (
+    <Modal
+      visible={open}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        <RNView
+          onStartShouldSetResponder={() => true}
+          style={{ maxWidth: 400, width: "100%", alignSelf: "center" }}
+        >
+          <YStack
+            bg="$background"
+            borderRadius="$5"
+            maxWidth={400}
+            width="100%"
+            alignSelf="center"
+            p="$4"
+            gap="$3"
+            borderWidth={1}
+            borderColor="$borderColor"
+          >
+            <Text
+              fontFamily="$baemin"
+              fontSize={rv({ sm: fs(18), md: fs(20), lg: fs(20) })}
+              fontWeight="700"
+              color="$mainText"
+            >
+              연도·월 선택
+            </Text>
+
+            <Text
+              fontFamily="$baemin"
+              fontSize={rv({ sm: fs(12), md: fs(13), lg: fs(13) })}
+              color="$gray"
+            >
+              연도
+            </Text>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.yearRow}
+            >
+              {yearRange.map((y) => {
+                const active = y === draftYear;
+                return (
+                  <Pressable
+                    key={y}
+                    onPress={() => setDraftYear(y)}
+                    style={[styles.yearChip, active && styles.yearChipActive]}
+                  >
+                    <RNText
+                      style={[
+                        styles.yearChipText,
+                        active && styles.yearChipTextActive,
+                      ]}
+                    >
+                      {y}
+                    </RNText>
+                  </Pressable>
+                );
+              })}
+            </ScrollView>
+
+            <Text
+              fontFamily="$baemin"
+              fontSize={rv({ sm: fs(12), md: fs(13), lg: fs(13) })}
+              color="$gray"
+            >
+              월
+            </Text>
+            <RNView style={styles.monthGrid}>
+              {MONTHS.map((m) => {
+                const active = m === draftMonth;
+                return (
+                  <Pressable
+                    key={m}
+                    onPress={() => setDraftMonth(m)}
+                    style={[styles.monthCell, active && styles.monthCellActive]}
+                  >
+                    <RNText
+                      style={[
+                        styles.monthCellText,
+                        active && styles.monthCellTextActive,
+                      ]}
+                    >
+                      {m}월
+                    </RNText>
+                  </Pressable>
+                );
+              })}
+            </RNView>
+
+            <YStack gap="$2" pt="$2">
+              <Button
+                size="$4"
+                bg="$primary"
+                fontFamily="$baemin"
+                onPress={() => onConfirm(draftYear, draftMonth)}
+              >
+                확인
+              </Button>
+              <Button
+                size="$4"
+                variant="outlined"
+                borderColor="$gray8"
+                fontFamily="$baemin"
+                color="$gray"
+                onPress={onClose}
+              >
+                취소
+              </Button>
+            </YStack>
+          </YStack>
+        </RNView>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.45)",
+    justifyContent: "center",
+    paddingHorizontal: ms(20),
+  },
+  yearRow: {
+    gap: ms(8),
+    paddingVertical: ms(4),
+    flexDirection: "row",
+  },
+  yearChip: {
+    paddingHorizontal: ms(16),
+    paddingVertical: ms(10),
+    borderRadius: ms(12),
+    backgroundColor: "#F3F4F6",
+    minWidth: ms(72),
+    alignItems: "center",
+  },
+  yearChipActive: {
+    backgroundColor: "#2BEEAD",
+  },
+  yearChipText: {
+    fontFamily: "BMJUA",
+    fontSize: rv({ sm: fs(15), md: fs(16), lg: fs(16) }),
+    color: "#374151",
+  },
+  yearChipTextActive: {
+    color: "#065F46",
+    fontWeight: "700",
+  },
+  monthGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: ms(8),
+    justifyContent: "flex-start",
+  },
+  monthCell: {
+    width: "22%",
+    paddingVertical: ms(10),
+    borderRadius: ms(12),
+    backgroundColor: "#F3F4F6",
+    alignItems: "center",
+  },
+  monthCellActive: {
+    backgroundColor: "#2BEEAD",
+  },
+  monthCellText: {
+    fontFamily: "BMJUA",
+    fontSize: rv({ sm: fs(14), md: fs(15), lg: fs(15) }),
+    color: "#374151",
+  },
+  monthCellTextActive: {
+    color: "#065F46",
+    fontWeight: "700",
+  },
+});

--- a/src/features/calendar/utils/calendar.ts
+++ b/src/features/calendar/utils/calendar.ts
@@ -1,5 +1,10 @@
 import { FoodItem, FoodStatus } from "@/shared/types/food";
 
+export const pad2 = (n: number) => (n < 10 ? `0${n}` : `${n}`);
+
+export const daysInMonth = (year: number, month: number) =>
+  new Date(year, month, 0).getDate();
+
 const STATUS_DOT_COLOR: Record<FoodStatus, string> = {
   GREEN: "#22C55E",
   YELLOW: "#F97316",


### PR DESCRIPTION
## 작업 내용

- 유통기한 캘린더 상단의 연·월 표시를 누르면 모달에서 연도·월을 고를 수 있게 함 
- 연도 스크롤은 2026년부터 보이도록 함

## 연관 이슈

- #137 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 달력에서 특정 월/연도로 빠르게 이동할 수 있는 기능 추가
  * 월/연도 선택 모달 UI 추가 - 칩 형태의 연도와 그리드 형태의 월 선택 인터페이스 제공
  * 헤더를 통해 모달 열기 및 선택한 월/연도로 자동 이동 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->