### PR TITLE
Fix: 알림 시간 설정 시트 성능 개선 및 선택 시간 초기 포커스 수정

### DIFF
--- a/src/features/notification/components/TimePicker/PickerColumn.tsx
+++ b/src/features/notification/components/TimePicker/PickerColumn.tsx
@@ -1,23 +1,108 @@
-import React from "react";
-import { ScrollView, Text, View, YStack } from "tamagui";
+import React, { memo, useCallback, useMemo } from "react";
+import {
+  FlatList,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  ScrollView,
+} from "react-native";
+
+import { Text, View, YStack } from "tamagui";
+
 import { PICKER_ITEM_HEIGHT } from "../../constants";
 import { PickerColumnProps } from "../../types";
 
-export const PickerColumn = ({
+const LIST_VIRTUALIZE_THRESHOLD = 24;
+
+const contentPadding = { paddingVertical: PICKER_ITEM_HEIGHT };
+
+const getItemLayout = (_: unknown, index: number) => ({
+  length: PICKER_ITEM_HEIGHT,
+  offset: PICKER_ITEM_HEIGHT + index * PICKER_ITEM_HEIGHT,
+  index,
+});
+
+type RowProps = {
+  item: string | number;
+  selected: string | number;
+  format: (value: string | number) => string;
+};
+
+const PickerRow = memo(function PickerRow({
+  item,
+  selected,
+  format,
+}: RowProps) {
+  const isSelected = selected === item;
+  return (
+    <View h={PICKER_ITEM_HEIGHT} jc="center" ai="center">
+      <Text
+        fontSize={isSelected ? "$5" : "$4"}
+        fontWeight={isSelected ? "700" : "400"}
+        color={isSelected ? "$primary" : "$gray8"}
+        opacity={isSelected ? 1 : 0.4}
+      >
+        {format(item)}
+      </Text>
+    </View>
+  );
+});
+
+function PickerColumnInner({
   items,
   selected,
   onSelect,
   format = (v) => v,
   width = 80,
-}: PickerColumnProps) => {
-  const handleScroll = (e: any) => {
-    const y = e.nativeEvent.contentOffset.y;
-    const index = Math.round(y / PICKER_ITEM_HEIGHT);
+}: PickerColumnProps) {
+  const handleScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const y = e.nativeEvent.contentOffset.y;
+      const index = Math.round(y / PICKER_ITEM_HEIGHT);
 
-    if (items[index] !== undefined && items[index] !== selected) {
-      onSelect(items[index]);
-    }
-  };
+      if (items[index] !== undefined && items[index] !== selected) {
+        onSelect(items[index]);
+      }
+    },
+    [items, onSelect, selected],
+  );
+
+  const selectedIndex = useMemo(() => {
+    const i = items.indexOf(selected);
+    return i >= 0 ? i : 0;
+  }, [items, selected]);
+
+  const renderItem = useCallback(
+    ({ item }: { item: string | number }) => (
+      <PickerRow item={item} selected={selected} format={format} />
+    ),
+    [format, selected],
+  );
+
+  const keyExtractor = useCallback((item: string | number) => String(item), []);
+
+  if (items.length > LIST_VIRTUALIZE_THRESHOLD) {
+    return (
+      <YStack width={width} h={PICKER_ITEM_HEIGHT * 3} pos="relative">
+        <FlatList
+          data={items}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          showsVerticalScrollIndicator={false}
+          snapToInterval={PICKER_ITEM_HEIGHT}
+          decelerationRate="fast"
+          onScroll={handleScroll}
+          scrollEventThrottle={16}
+          contentContainerStyle={contentPadding}
+          getItemLayout={getItemLayout}
+          initialScrollIndex={selectedIndex}
+          removeClippedSubviews
+          windowSize={7}
+          maxToRenderPerBatch={12}
+          initialNumToRender={14}
+        />
+      </YStack>
+    );
+  }
 
   return (
     <YStack width={width} h={PICKER_ITEM_HEIGHT * 3} pos="relative">
@@ -27,27 +112,21 @@ export const PickerColumn = ({
         decelerationRate="fast"
         onScroll={handleScroll}
         scrollEventThrottle={16}
-        contentContainerStyle={{ paddingVertical: PICKER_ITEM_HEIGHT }}
+        contentContainerStyle={contentPadding}
       >
         <YStack ai="center">
-          {items.map((item) => {
-            const isSelected = selected === item;
-            return (
-              <View key={item} h={PICKER_ITEM_HEIGHT} jc="center" ai="center">
-                <Text
-                  fontSize={isSelected ? "$5" : "$4"}
-                  fontWeight={isSelected ? "700" : "400"}
-                  color={isSelected ? "$primary" : "$gray8"}
-                  opacity={isSelected ? 1 : 0.4}
-                  animation="quick"
-                >
-                  {format(item)}
-                </Text>
-              </View>
-            );
-          })}
+          {items.map((item) => (
+            <PickerRow
+              key={String(item)}
+              item={item}
+              selected={selected}
+              format={format}
+            />
+          ))}
         </YStack>
       </ScrollView>
     </YStack>
   );
-};
+}
+
+export const PickerColumn = memo(PickerColumnInner);

--- a/src/features/notification/components/TimePicker/PickerColumn.tsx
+++ b/src/features/notification/components/TimePicker/PickerColumn.tsx
@@ -1,4 +1,10 @@
-import React, { memo, useCallback, useMemo } from "react";
+import React, {
+  memo,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react";
 import {
   FlatList,
   NativeScrollEvent,
@@ -24,7 +30,7 @@ const getItemLayout = (_: unknown, index: number) => ({
 type RowProps = {
   item: string | number;
   selected: string | number;
-  format: (value: string | number) => string;
+  format: (value: string | number) => string | number;
 };
 
 const PickerRow = memo(function PickerRow({
@@ -54,6 +60,9 @@ function PickerColumnInner({
   format = (v) => v,
   width = 80,
 }: PickerColumnProps) {
+  const scrollRef = useRef<ScrollView>(null);
+  const listRef = useRef<FlatList<string | number>>(null);
+
   const handleScroll = useCallback(
     (e: NativeSyntheticEvent<NativeScrollEvent>) => {
       const y = e.nativeEvent.contentOffset.y;
@@ -71,6 +80,15 @@ function PickerColumnInner({
     return i >= 0 ? i : 0;
   }, [items, selected]);
 
+  useLayoutEffect(() => {
+    const y = selectedIndex * PICKER_ITEM_HEIGHT;
+    if (items.length > LIST_VIRTUALIZE_THRESHOLD) {
+      listRef.current?.scrollToOffset({ offset: y, animated: false });
+    } else {
+      scrollRef.current?.scrollTo({ y, animated: false });
+    }
+  }, []);
+
   const renderItem = useCallback(
     ({ item }: { item: string | number }) => (
       <PickerRow item={item} selected={selected} format={format} />
@@ -84,6 +102,7 @@ function PickerColumnInner({
     return (
       <YStack width={width} h={PICKER_ITEM_HEIGHT * 3} pos="relative">
         <FlatList
+          ref={listRef}
           data={items}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
@@ -94,7 +113,6 @@ function PickerColumnInner({
           scrollEventThrottle={16}
           contentContainerStyle={contentPadding}
           getItemLayout={getItemLayout}
-          initialScrollIndex={selectedIndex}
           removeClippedSubviews
           windowSize={7}
           maxToRenderPerBatch={12}
@@ -107,6 +125,7 @@ function PickerColumnInner({
   return (
     <YStack width={width} h={PICKER_ITEM_HEIGHT * 3} pos="relative">
       <ScrollView
+        ref={scrollRef}
         showsVerticalScrollIndicator={false}
         snapToInterval={PICKER_ITEM_HEIGHT}
         decelerationRate="fast"

--- a/src/features/notification/components/TimePicker/TimePickerSelect.tsx
+++ b/src/features/notification/components/TimePicker/TimePickerSelect.tsx
@@ -14,11 +14,14 @@ const TimePickerSelectBase = ({
 }: TimePickerSelectProps) => {
   const [open, setOpen] = useState(false);
   const [tempValue, setTempValue] = useState(value);
+  const [pickerSession, setPickerSession] = useState(0);
   const insets = useSafeAreaInsets();
 
   useEffect(() => {
-    if (open) setTempValue(value);
-  }, [open, value]);
+    if (!open) {
+      setTempValue(value);
+    }
+  }, [value, open]);
 
   const parseValue = useCallback((val: string) => {
     const [h, m] = val.split(":").map(Number);
@@ -64,6 +67,8 @@ const TimePickerSelectBase = ({
         disabled={disabled}
         onPress={() => {
           if (disabled) return;
+          setTempValue(value);
+          setPickerSession((s) => s + 1);
           setOpen(true);
         }}
       >
@@ -124,6 +129,7 @@ const TimePickerSelectBase = ({
                 />
 
                 <PickerColumn
+                  key={`ampm-${pickerSession}`}
                   items={AM_PM}
                   selected={isPm ? "오후" : "오전"}
                   onSelect={(val) => handleTempSelect({ isPm: val === "오후" })}
@@ -133,6 +139,7 @@ const TimePickerSelectBase = ({
                   :
                 </Text>
                 <PickerColumn
+                  key={`hour-${pickerSession}`}
                   items={HOURS}
                   selected={hour}
                   onSelect={(val) => handleTempSelect({ hour: val })}
@@ -143,6 +150,7 @@ const TimePickerSelectBase = ({
                   :
                 </Text>
                 <PickerColumn
+                  key={`minute-${pickerSession}`}
                   items={MINUTES}
                   selected={minute}
                   onSelect={(val) => handleTempSelect({ minute: val })}


### PR DESCRIPTION
## 작업 내용

- 분 단위 항목이 많은 컬럼은 ScrollView 전체 렌더 대신 FlatList로 가상화.
- 행 단위 memo, Tamagui Text의 animation 제거로 오픈 시 레이아웃·애니메이션 비용 감소.
- 오전/오후·시 등 짧은 목록은 기존 ScrollView 유지.
- 컬럼 마운트 시 useLayoutEffect로 선택 인덱스에 맞게 스크롤 오프셋 적용(오전/오후·시·분 모두 현재 설정에 맞춤)

## 연관 이슈

- #139


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 시간 선택기의 대량 항목 처리 시 성능 최적화 적용

* **버그 수정**
  * 시간 선택기의 초기 스크롤 위치 설정 개선
  * 시간 선택 시 상태 관리 로직 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->