### PR TITLE
Feat: 커스텀 바텀시트 드래그-다운 닫기 추가

### DIFF
--- a/src/features/food-add/components/CategorySelector/CategoryActionSheet.tsx
+++ b/src/features/food-add/components/CategorySelector/CategoryActionSheet.tsx
@@ -1,8 +1,16 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getBottomPaddingForSheet, ms, s } from "@/shared/constants/layout";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   Animated,
   Easing,
   Modal,
+  PanResponder,
   Pressable,
   StyleSheet,
   useWindowDimensions,
@@ -10,7 +18,6 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Button, Text, View, XStack, YStack } from "tamagui";
 import { CategoryActionSheetProps } from "../../types";
-import { getBottomPaddingForSheet, ms, s } from "@/shared/constants/layout";
 
 export const CategoryActionSheet = ({
   visible,
@@ -39,6 +46,32 @@ export const CategoryActionSheet = ({
     () => Math.max(50, Math.round(windowHeight * 0.25)),
     [windowHeight],
   );
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: (_, gestureState) => {
+        return Math.abs(gestureState.dy) > 5;
+      },
+      onPanResponderMove: (_, gestureState) => {
+        if (gestureState.dy > 0) {
+          translateY.setValue(gestureState.dy);
+        }
+      },
+      onPanResponderRelease: (_, gestureState) => {
+        if (gestureState.dy > 100 || gestureState.vy > 0.5) {
+          onClose();
+        } else {
+          Animated.spring(translateY, {
+            toValue: 0,
+            useNativeDriver: true,
+            friction: 8,
+            tension: 40,
+          }).start();
+        }
+      },
+    }),
+  ).current;
 
   const runClose = useCallback(() => {
     if (isExitAnimatingRef.current) return;
@@ -117,7 +150,14 @@ export const CategoryActionSheet = ({
       return;
     }
     runClose();
-  }, [backdropOpacity, runClose, sheetHiddenY, sheetOpacity, translateY, visible]);
+  }, [
+    backdropOpacity,
+    runClose,
+    sheetHiddenY,
+    sheetOpacity,
+    translateY,
+    visible,
+  ]);
 
   return (
     <Modal
@@ -140,6 +180,7 @@ export const CategoryActionSheet = ({
             transform: [{ translateY }],
             opacity: sheetOpacity,
           }}
+          {...panResponder.panHandlers}
         >
           <YStack
             bg="$background"

--- a/src/features/food-add/components/CategorySelector/CategoryFormSheet.tsx
+++ b/src/features/food-add/components/CategorySelector/CategoryFormSheet.tsx
@@ -1,5 +1,11 @@
 import { getBottomPaddingForSheet, ms, s } from "@/shared/constants/layout";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Controller, useForm } from "react-hook-form";
 import {
   Animated,
@@ -8,6 +14,7 @@ import {
   Keyboard,
   KeyboardAvoidingView,
   Modal,
+  PanResponder,
   Platform,
   Pressable,
   StyleSheet,
@@ -47,6 +54,32 @@ export const CategoryFormSheet = ({
     () => Math.max(50, Math.round(windowHeight * 0.25)),
     [windowHeight],
   );
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: (_, gestureState) => {
+        return Math.abs(gestureState.dy) > 5;
+      },
+      onPanResponderMove: (_, gestureState) => {
+        if (gestureState.dy > 0) {
+          translateY.setValue(gestureState.dy);
+        }
+      },
+      onPanResponderRelease: (_, gestureState) => {
+        if (gestureState.dy > 100 || gestureState.vy > 0.5) {
+          onClose();
+        } else {
+          Animated.spring(translateY, {
+            toValue: 0,
+            useNativeDriver: true,
+            friction: 8,
+            tension: 40,
+          }).start();
+        }
+      },
+    }),
+  ).current;
 
   const {
     control,
@@ -153,7 +186,14 @@ export const CategoryFormSheet = ({
       return;
     }
     runClose();
-  }, [backdropOpacity, runClose, sheetHiddenY, sheetOpacity, translateY, visible]);
+  }, [
+    backdropOpacity,
+    runClose,
+    sheetHiddenY,
+    sheetOpacity,
+    translateY,
+    visible,
+  ]);
 
   useEffect(() => {
     if (!visible || !show || isEditMode) return;
@@ -221,6 +261,7 @@ export const CategoryFormSheet = ({
               transform: [{ translateY }],
               opacity: sheetOpacity,
             }}
+            {...panResponder.panHandlers}
           >
             <YStack
               bg="$background"

--- a/src/features/fridge-management/components/FridgeNameEditSheet.tsx
+++ b/src/features/fridge-management/components/FridgeNameEditSheet.tsx
@@ -1,5 +1,11 @@
 import { fs, getBottomPaddingForSheet, ms, s } from "@/shared/constants/layout";
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   Animated,
   Easing,
@@ -7,6 +13,7 @@ import {
   Keyboard,
   KeyboardAvoidingView,
   Modal,
+  PanResponder,
   Platform,
   Pressable,
   StyleSheet,
@@ -45,6 +52,32 @@ export const FridgeNameEditSheet = ({
     () => Math.max(50, Math.round(windowHeight * 0.25)),
     [windowHeight],
   );
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: (_, gestureState) => {
+        return Math.abs(gestureState.dy) > 5;
+      },
+      onPanResponderMove: (_, gestureState) => {
+        if (gestureState.dy > 0) {
+          translateY.setValue(gestureState.dy);
+        }
+      },
+      onPanResponderRelease: (_, gestureState) => {
+        if (gestureState.dy > 100 || gestureState.vy > 0.5) {
+          onClose();
+        } else {
+          Animated.spring(translateY, {
+            toValue: 0,
+            useNativeDriver: true,
+            friction: 8,
+            tension: 40,
+          }).start();
+        }
+      },
+    }),
+  ).current;
 
   useEffect(() => {
     if (visible) {
@@ -137,7 +170,14 @@ export const FridgeNameEditSheet = ({
       return;
     }
     runClose();
-  }, [backdropOpacity, runClose, sheetHiddenY, sheetOpacity, translateY, visible]);
+  }, [
+    backdropOpacity,
+    runClose,
+    sheetHiddenY,
+    sheetOpacity,
+    translateY,
+    visible,
+  ]);
 
   useEffect(() => {
     if (!visible || !show) return;
@@ -191,6 +231,7 @@ export const FridgeNameEditSheet = ({
               transform: [{ translateY }],
               opacity: sheetOpacity,
             }}
+            {...panResponder.panHandlers}
           >
             <YStack
               bg="$background"
@@ -202,13 +243,7 @@ export const FridgeNameEditSheet = ({
               borderBottomRightRadius={0}
               zIndex={100}
             >
-              <View
-                w={s(40)}
-                h={s(5)}
-                bg="$gray4"
-                br="$4"
-                alignSelf="center"
-              />
+              <View w={s(40)} h={s(5)} bg="$gray4" br="$4" alignSelf="center" />
 
               <YStack gap="$2">
                 <Text fontSize="$4" fontWeight="700" fontFamily="$baemin">

--- a/src/features/fridge-management/components/FridgeSelectionSheet.tsx
+++ b/src/features/fridge-management/components/FridgeSelectionSheet.tsx
@@ -21,6 +21,8 @@ import {
 } from "tamagui";
 import { FridgeSelectionProps } from "../types";
 
+const AnimatedYStack = Animated.createAnimatedComponent(YStack);
+
 export const FridgeSelectionSheet = ({
   visible,
   onClose,
@@ -52,8 +54,6 @@ export const FridgeSelectionSheet = ({
       },
     }),
   ).current;
-
-  const AnimatedYStack = Animated.createAnimatedComponent(YStack);
 
   return (
     <Modal

--- a/src/features/fridge-management/components/FridgeSelectionSheet.tsx
+++ b/src/features/fridge-management/components/FridgeSelectionSheet.tsx
@@ -1,7 +1,14 @@
+import { fs, getBottomPaddingForSheet, s } from "@/shared/constants/layout";
 import { Check, PlusCircle, Refrigerator } from "@tamagui/lucide-icons";
 import { router } from "expo-router";
-import React from "react";
-import { Modal, Pressable, StyleSheet } from "react-native";
+import React, { useRef } from "react";
+import {
+  Animated,
+  Modal,
+  PanResponder,
+  Pressable,
+  StyleSheet,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   AnimatePresence,
@@ -13,7 +20,6 @@ import {
   YStack,
 } from "tamagui";
 import { FridgeSelectionProps } from "../types";
-import { fs, getBottomPaddingForSheet, ms, s } from "@/shared/constants/layout";
 
 export const FridgeSelectionSheet = ({
   visible,
@@ -23,6 +29,31 @@ export const FridgeSelectionSheet = ({
   onSelect,
 }: FridgeSelectionProps) => {
   const insets = useSafeAreaInsets();
+  const translateY = useRef(new Animated.Value(0)).current;
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: (_, gestureState) => gestureState.dy > 5,
+      onPanResponderMove: (_, gestureState) => {
+        if (gestureState.dy > 0) translateY.setValue(gestureState.dy);
+      },
+      onPanResponderRelease: (_, gestureState) => {
+        if (gestureState.dy > 120 || gestureState.vy > 0.5) {
+          onClose();
+          setTimeout(() => translateY.setValue(0), 200);
+        } else {
+          Animated.spring(translateY, {
+            toValue: 0,
+            useNativeDriver: true,
+            friction: 8,
+          }).start();
+        }
+      },
+    }),
+  ).current;
+
+  const AnimatedYStack = Animated.createAnimatedComponent(YStack);
 
   return (
     <Modal
@@ -49,12 +80,10 @@ export const FridgeSelectionSheet = ({
 
         <AnimatePresence>
           {visible && (
-            <YStack
+            <AnimatedYStack
               key="fridge-selection-sheet"
               bg="$background"
-              p="$5"
               pb={getBottomPaddingForSheet({ bottomInset: insets.bottom })}
-              gap="$4"
               br="$6"
               borderBottomLeftRadius={0}
               borderBottomRightRadius={0}
@@ -62,24 +91,32 @@ export const FridgeSelectionSheet = ({
               animation="quick"
               enterStyle={{ y: 300, opacity: 0 }}
               exitStyle={{ y: 300, opacity: 0 }}
-              y={0}
-              opacity={1}
-              maxHeight="70%"
+              style={{
+                transform: [{ translateY }],
+              }}
+              maxHeight="75%"
             >
-              <View
-                w={s(40)}
-                h={s(5)}
-                bg="$gray4"
-                br="$4"
-                alignSelf="center"
-                mb="$2"
-              />
+              <YStack {...panResponder.panHandlers} py="$3" ai="center">
+                <View w={s(40)} h={s(5)} bg="$gray4" br="$4" />
+              </YStack>
 
-              <Text fontSize="$6" fontWeight="700" fontFamily="$baemin" mb="$2">
+              <Text
+                px="$5"
+                pb="$3"
+                fontSize="$6"
+                fontWeight="700"
+                fontFamily="$baemin"
+              >
                 냉장고 선택
               </Text>
 
-              <ScrollView showsVerticalScrollIndicator={false}>
+              <ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={{
+                  paddingHorizontal: s(20),
+                  paddingBottom: s(10),
+                }}
+              >
                 <YStack gap="$3">
                   {fridges.map((fridge) => {
                     const isSelected = fridge.id === selectedId;
@@ -88,15 +125,15 @@ export const FridgeSelectionSheet = ({
                         key={fridge.id}
                         p="$4"
                         br="$5"
-                        borderWidth={1}
-                        borderColor={isSelected ? "$primary" : "$gray2"}
-                        backgroundColor="$gray2"
+                        bw={1}
+                        bc={isSelected ? "$primary" : "$gray2"}
+                        bg="$gray2"
                         ai="center"
                         jc="space-between"
                         onPress={() => onSelect(fridge.id)}
                       >
                         <XStack gap="$3" ai="center">
-                          <View p="$2" br="$2" backgroundColor="$gray2">
+                          <View p="$2" br="$2" bg="$gray2">
                             <Refrigerator
                               size={s(24)}
                               color={isSelected ? "$primary" : "$gray10"}
@@ -121,7 +158,7 @@ export const FridgeSelectionSheet = ({
                         </XStack>
 
                         {isSelected && (
-                          <Circle size={s(22)} bc="$primary">
+                          <Circle size={s(22)} bc="$primary" bg="$primary">
                             <Check size={s(14)} color="$white" />
                           </Circle>
                         )}
@@ -137,18 +174,16 @@ export const FridgeSelectionSheet = ({
                     br="$5"
                     borderStyle="dashed"
                     borderWidth={1}
-                    bc="$background"
+                    bc="$white"
                     mt="$2"
-                    pressStyle={{ opacity: 0.7 }}
-                    opacity={0.6}
                     onPress={() => {
                       onClose();
                       router.push("/fridge-add");
                     }}
                   >
-                    <PlusCircle size={s(18)} color="$mainText" />
+                    <PlusCircle size={s(18)} color="$gray10" />
                     <Text
-                      color="$mainText"
+                      color="$gray10"
                       fontWeight="600"
                       fontFamily="$baemin"
                       fontSize={fs(14)}
@@ -158,7 +193,7 @@ export const FridgeSelectionSheet = ({
                   </XStack>
                 </YStack>
               </ScrollView>
-            </YStack>
+            </AnimatedYStack>
           )}
         </AnimatePresence>
       </YStack>
@@ -167,7 +202,5 @@ export const FridgeSelectionSheet = ({
 };
 
 const styles = StyleSheet.create({
-  backdrop: {
-    ...StyleSheet.absoluteFillObject,
-  },
+  backdrop: { ...StyleSheet.absoluteFillObject },
 });

--- a/src/features/home/components/SortFilter.tsx
+++ b/src/features/home/components/SortFilter.tsx
@@ -1,9 +1,24 @@
-import { useEffect, useState } from "react";
-import { Modal, Pressable, ScrollView, StyleSheet } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { AnimatePresence, Button, Text, View, XStack, YStack } from "tamagui";
-import { SortFilterProps, SortOption } from "../types";
 import { fs, getBottomPaddingForSheet, ms, s } from "@/shared/constants/layout";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  Animated,
+  Easing,
+  Modal,
+  PanResponder,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  useWindowDimensions,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Button, Text, View, XStack, YStack } from "tamagui";
+import { SortFilterProps, SortOption } from "../types";
 
 const SORT_OPTIONS: { label: string; value: SortOption }[] = [
   { label: "유통기한 임박순", value: "EXPIRY_ASC" },
@@ -23,6 +38,24 @@ export function SortFilter({
   const [draftSort, setDraftSort] = useState<SortOption>(selectedSort);
   const [draftCategory, setDraftCategory] = useState(selectedCategory);
   const insets = useSafeAreaInsets();
+  const { height: windowHeight } = useWindowDimensions();
+
+  const visibleRef = useRef(visible);
+  visibleRef.current = visible;
+
+  const [show, setShow] = useState(false);
+  const translateY = useRef(new Animated.Value(0)).current;
+  const dragY = useRef(new Animated.Value(0)).current;
+  const sheetOpacity = useRef(new Animated.Value(0)).current;
+  const backdropOpacity = useRef(new Animated.Value(0)).current;
+  const isEnterAnimatingRef = useRef(false);
+  const isExitAnimatingRef = useRef(false);
+  const hasOpenedRef = useRef(false);
+
+  const sheetHiddenY = useMemo(
+    () => Math.max(60, Math.round(windowHeight * 0.2)),
+    [windowHeight],
+  );
 
   useEffect(() => {
     if (!visible) return;
@@ -30,151 +63,265 @@ export function SortFilter({
     setDraftCategory(selectedCategory);
   }, [visible, selectedSort, selectedCategory]);
 
+  const runClose = useCallback(() => {
+    if (isExitAnimatingRef.current) return;
+    isExitAnimatingRef.current = true;
+    dragY.setValue(0);
+
+    Animated.parallel([
+      Animated.timing(backdropOpacity, {
+        toValue: 0,
+        duration: 140,
+        easing: Easing.out(Easing.quad),
+        useNativeDriver: true,
+      }),
+      Animated.timing(sheetOpacity, {
+        toValue: 0,
+        duration: 140,
+        easing: Easing.out(Easing.quad),
+        useNativeDriver: true,
+      }),
+      Animated.timing(translateY, {
+        toValue: sheetHiddenY,
+        duration: 180,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }),
+    ]).start(({ finished }) => {
+      isExitAnimatingRef.current = false;
+      if (finished) setShow(false);
+    });
+  }, [backdropOpacity, dragY, sheetHiddenY, sheetOpacity, translateY]);
+
+  useEffect(() => {
+    if (visible) {
+      hasOpenedRef.current = true;
+      setShow(true);
+      requestAnimationFrame(() => {
+        isEnterAnimatingRef.current = true;
+        translateY.setValue(sheetHiddenY);
+        dragY.setValue(0);
+        sheetOpacity.setValue(0);
+        backdropOpacity.setValue(0);
+        Animated.parallel([
+          Animated.timing(backdropOpacity, {
+            toValue: 1,
+            duration: 160,
+            easing: Easing.out(Easing.quad),
+            useNativeDriver: true,
+          }),
+          Animated.timing(sheetOpacity, {
+            toValue: 1,
+            duration: 180,
+            easing: Easing.out(Easing.quad),
+            useNativeDriver: true,
+          }),
+          Animated.timing(translateY, {
+            toValue: 0,
+            duration: 220,
+            easing: Easing.out(Easing.cubic),
+            useNativeDriver: true,
+          }),
+        ]).start(() => {
+          isEnterAnimatingRef.current = false;
+          if (!visibleRef.current) {
+            runClose();
+          }
+        });
+      });
+      return;
+    }
+
+    if (!hasOpenedRef.current) return;
+    if (isEnterAnimatingRef.current) return;
+    runClose();
+  }, [
+    backdropOpacity,
+    dragY,
+    runClose,
+    sheetHiddenY,
+    sheetOpacity,
+    translateY,
+    visible,
+  ]);
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: (_, gestureState) => {
+        return Math.abs(gestureState.dy) > 5;
+      },
+      onPanResponderMove: (_, gestureState) => {
+        if (gestureState.dy > 0) {
+          dragY.setValue(gestureState.dy);
+        }
+      },
+      onPanResponderRelease: (_, gestureState) => {
+        if (gestureState.dy > 100 || gestureState.vy > 0.5) {
+          onClose();
+          dragY.setValue(0);
+        } else {
+          Animated.spring(dragY, {
+            toValue: 0,
+            useNativeDriver: true,
+            friction: 8,
+            tension: 40,
+          }).start();
+        }
+      },
+      onPanResponderTerminate: () => {
+        Animated.spring(dragY, {
+          toValue: 0,
+          useNativeDriver: true,
+          friction: 8,
+          tension: 40,
+        }).start();
+      },
+    }),
+  ).current;
+
   return (
     <Modal
-      visible={visible}
+      visible={show}
       transparent
       animationType="none"
       onRequestClose={onClose}
       statusBarTranslucent
     >
       <YStack f={1} jc="flex-end">
-        <Pressable style={styles.backdrop} onPress={onClose} />
+        <Pressable style={StyleSheet.absoluteFill} onPress={onClose}>
+          <Animated.View
+            style={[styles.backdrop, { opacity: backdropOpacity }]}
+          />
+        </Pressable>
 
-        <AnimatePresence>
-          {visible && (
-            <YStack
-              key="sort-filter-sheet"
-              bg="$background"
-              p="$5"
-              pb={getBottomPaddingForSheet({ bottomInset: insets.bottom })}
-              gap="$5"
-              br="$6"
-              borderBottomLeftRadius={0}
-              borderBottomRightRadius={0}
-              animation="quick"
-              enterStyle={{ y: 80, opacity: 0 }}
-              exitStyle={{ y: 80, opacity: 0 }}
-              y={0}
-              opacity={1}
-            >
-              <View
-                w={s(56)}
-                h={s(6)}
-                bg="$gray4"
-                br="$4"
-                alignSelf="center"
-              />
+        <Animated.View
+          style={{
+            transform: [{ translateY: Animated.add(translateY, dragY) }],
+            opacity: sheetOpacity,
+          }}
+          {...panResponder.panHandlers}
+        >
+          <YStack
+            key="sort-filter-sheet"
+            bg="$background"
+            p="$5"
+            pb={getBottomPaddingForSheet({ bottomInset: insets.bottom })}
+            gap="$5"
+            br="$6"
+            borderBottomLeftRadius={0}
+            borderBottomRightRadius={0}
+          >
+            <View w={s(56)} h={s(6)} bg="$gray4" br="$4" alignSelf="center" />
 
-              <XStack ai="center" jc="space-between">
-                <Text fontSize={fs(16)} fontWeight="700" fontFamily="$baemin">
-                  정렬 및 필터
-                </Text>
-              </XStack>
+            <XStack ai="center" jc="space-between">
+              <Text fontSize={fs(16)} fontWeight="700" fontFamily="$baemin">
+                정렬 및 필터
+              </Text>
+            </XStack>
 
-              <YStack gap="$3">
-                <Text fontSize={fs(14)} fontWeight="700" fontFamily="$heading">
-                  정렬 기준
-                </Text>
+            <YStack gap="$3">
+              <Text fontSize={fs(14)} fontWeight="700" fontFamily="$heading">
+                정렬 기준
+              </Text>
 
-                {SORT_OPTIONS.map((option) => {
-                  const isActive = draftSort === option.value;
-                  return (
-                    <Button
-                      key={option.value}
-                      h={ms(52)}
-                      bg="$surface"
-                      boc="$gray3"
-                      bw={1}
-                      br="$6"
-                      onPress={() => setDraftSort(option.value)}
-                      pressStyle={{ scale: 0.98 }}
-                    >
-                      <XStack f={1} ai="center" jc="space-between" px="$1">
+              {SORT_OPTIONS.map((option) => {
+                const isActive = draftSort === option.value;
+                return (
+                  <Button
+                    key={option.value}
+                    h={ms(52)}
+                    bg="$surface"
+                    boc="$gray3"
+                    bw={1}
+                    br="$6"
+                    onPress={() => setDraftSort(option.value)}
+                    pressStyle={{ scale: 0.98 }}
+                  >
+                    <XStack f={1} ai="center" jc="space-between" px="$1">
+                      <Text
+                        fontSize={fs(14)}
+                        fontWeight="700"
+                        color="$mainText"
+                        fontFamily="$baemin"
+                      >
+                        {option.label}
+                      </Text>
+
+                      <View
+                        w={s(30)}
+                        h={s(30)}
+                        br={999}
+                        bw={s(3)}
+                        boc={isActive ? "$primary" : "$gray3"}
+                        ai="center"
+                        jc="center"
+                      >
+                        {isActive && (
+                          <View w={s(12)} h={s(12)} br={999} bg="$primary" />
+                        )}
+                      </View>
+                    </XStack>
+                  </Button>
+                );
+              })}
+            </YStack>
+
+            <YStack gap="$3">
+              <Text fontSize={fs(14)} fontWeight="700" fontFamily="$heading">
+                카테고리
+              </Text>
+
+              <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                <XStack gap="$2" pr="$4">
+                  {categories.map((category) => {
+                    const isActive = draftCategory === category;
+                    return (
+                      <Button
+                        key={category}
+                        backgroundColor={isActive ? "$primary" : "$gray3"}
+                        br="$4"
+                        px="$4"
+                        size="$4"
+                        onPress={() => setDraftCategory(category)}
+                        pressStyle={{ scale: 0.97 }}
+                        h={ms(40)}
+                      >
                         <Text
-                          fontSize={fs(14)}
+                          fontFamily="$baemin"
+                          fontSize={fs(13)}
                           fontWeight="700"
                           color="$mainText"
-                          fontFamily="$baemin"
                         >
-                          {option.label}
+                          {category}
                         </Text>
-
-                        <View
-                          w={s(30)}
-                          h={s(30)}
-                          br={999}
-                          bw={s(3)}
-                          boc={isActive ? "$primary" : "$gray3"}
-                          ai="center"
-                          jc="center"
-                        >
-                          {isActive && (
-                            <View w={s(12)} h={s(12)} br={999} bg="$primary" />
-                          )}
-                        </View>
-                      </XStack>
-                    </Button>
-                  );
-                })}
-              </YStack>
-
-              <YStack gap="$3">
-                <Text fontSize={fs(14)} fontWeight="700" fontFamily="$heading">
-                  카테고리
-                </Text>
-
-                <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-                  <XStack gap="$2" pr="$4">
-                    {categories.map((category) => {
-                      const isActive = draftCategory === category;
-                      return (
-                        <Button
-                          key={category}
-                          backgroundColor={isActive ? "$primary" : "$gray3"}
-                          br="$4"
-                          px="$4"
-                          size="$4"
-                          onPress={() => setDraftCategory(category)}
-                          pressStyle={{ scale: 0.97 }}
-                          h={ms(40)}
-                        >
-                          <Text
-                            fontFamily="$baemin"
-                            fontSize={fs(13)}
-                            fontWeight="700"
-                            color="$mainText"
-                          >
-                            {category}
-                          </Text>
-                        </Button>
-                      );
-                    })}
-                  </XStack>
-                </ScrollView>
-              </YStack>
-
-              <Button
-                h={ms(52)}
-                br="$6"
-                bg="$primary"
-                mt="$2"
-                onPress={() => {
-                  onApply({
-                    sort: draftSort,
-                    category: draftCategory,
-                  });
-                  onClose();
-                }}
-                pressStyle={{ scale: 0.98 }}
-              >
-                <Text fontSize={fs(15)} fontWeight="700" fontFamily="$baemin">
-                  적용하기
-                </Text>
-              </Button>
+                      </Button>
+                    );
+                  })}
+                </XStack>
+              </ScrollView>
             </YStack>
-          )}
-        </AnimatePresence>
+
+            <Button
+              h={ms(52)}
+              br="$6"
+              bg="$primary"
+              mt="$2"
+              onPress={() => {
+                onApply({
+                  sort: draftSort,
+                  category: draftCategory,
+                });
+                onClose();
+              }}
+              pressStyle={{ scale: 0.98 }}
+            >
+              <Text fontSize={fs(15)} fontWeight="700" fontFamily="$baemin">
+                적용하기
+              </Text>
+            </Button>
+          </YStack>
+        </Animated.View>
       </YStack>
     </Modal>
   );

--- a/src/features/home/components/SortFilter.tsx
+++ b/src/features/home/components/SortFilter.tsx
@@ -63,35 +63,43 @@ export function SortFilter({
     setDraftCategory(selectedCategory);
   }, [visible, selectedSort, selectedCategory]);
 
-  const runClose = useCallback(() => {
-    if (isExitAnimatingRef.current) return;
-    isExitAnimatingRef.current = true;
-    dragY.setValue(0);
+  const requestClose = useCallback(
+    (notifyParent: boolean) => {
+      if (isExitAnimatingRef.current) return;
+      isExitAnimatingRef.current = true;
+      dragY.stopAnimation();
 
-    Animated.parallel([
-      Animated.timing(backdropOpacity, {
-        toValue: 0,
-        duration: 140,
-        easing: Easing.out(Easing.quad),
-        useNativeDriver: true,
-      }),
-      Animated.timing(sheetOpacity, {
-        toValue: 0,
-        duration: 140,
-        easing: Easing.out(Easing.quad),
-        useNativeDriver: true,
-      }),
-      Animated.timing(translateY, {
-        toValue: sheetHiddenY,
-        duration: 180,
-        easing: Easing.out(Easing.cubic),
-        useNativeDriver: true,
-      }),
-    ]).start(({ finished }) => {
-      isExitAnimatingRef.current = false;
-      if (finished) setShow(false);
-    });
-  }, [backdropOpacity, dragY, sheetHiddenY, sheetOpacity, translateY]);
+      Animated.parallel([
+        Animated.timing(backdropOpacity, {
+          toValue: 0,
+          duration: 140,
+          easing: Easing.out(Easing.quad),
+          useNativeDriver: true,
+        }),
+        Animated.timing(sheetOpacity, {
+          toValue: 0,
+          duration: 140,
+          easing: Easing.out(Easing.quad),
+          useNativeDriver: true,
+        }),
+        Animated.timing(translateY, {
+          toValue: sheetHiddenY,
+          duration: 180,
+          easing: Easing.out(Easing.cubic),
+          useNativeDriver: true,
+        }),
+      ]).start(({ finished }) => {
+        isExitAnimatingRef.current = false;
+        if (finished) {
+          dragY.setValue(0);
+          translateY.setValue(0);
+          setShow(false);
+          if (notifyParent) onClose();
+        }
+      });
+    },
+    [backdropOpacity, dragY, onClose, sheetHiddenY, sheetOpacity, translateY],
+  );
 
   useEffect(() => {
     if (visible) {
@@ -125,7 +133,7 @@ export function SortFilter({
         ]).start(() => {
           isEnterAnimatingRef.current = false;
           if (!visibleRef.current) {
-            runClose();
+            requestClose(false);
           }
         });
       });
@@ -134,11 +142,11 @@ export function SortFilter({
 
     if (!hasOpenedRef.current) return;
     if (isEnterAnimatingRef.current) return;
-    runClose();
+    requestClose(false);
   }, [
     backdropOpacity,
     dragY,
-    runClose,
+    requestClose,
     sheetHiddenY,
     sheetOpacity,
     translateY,
@@ -158,8 +166,7 @@ export function SortFilter({
       },
       onPanResponderRelease: (_, gestureState) => {
         if (gestureState.dy > 100 || gestureState.vy > 0.5) {
-          onClose();
-          dragY.setValue(0);
+          requestClose(true);
         } else {
           Animated.spring(dragY, {
             toValue: 0,
@@ -185,11 +192,14 @@ export function SortFilter({
       visible={show}
       transparent
       animationType="none"
-      onRequestClose={onClose}
+      onRequestClose={() => requestClose(true)}
       statusBarTranslucent
     >
       <YStack f={1} jc="flex-end">
-        <Pressable style={StyleSheet.absoluteFill} onPress={onClose}>
+        <Pressable
+          style={StyleSheet.absoluteFill}
+          onPress={() => requestClose(true)}
+        >
           <Animated.View
             style={[styles.backdrop, { opacity: backdropOpacity }]}
           />
@@ -312,7 +322,7 @@ export function SortFilter({
                   sort: draftSort,
                   category: draftCategory,
                 });
-                onClose();
+                requestClose(true);
               }}
               pressStyle={{ scale: 0.98 }}
             >


### PR DESCRIPTION
## 작업 내용

- 시트 영역을 아래로 드래그하면 임계치(dy, vy)에서 닫히도록 제스처 추가

## 연관 이슈

- #141


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 여러 시트 컴포넌트에 드래그-투-클로즈 제스처 추가: 아래로 드래그하여 시트를 닫을 수 있으며, 작은 드래그는 자동으로 원래 위치로 복귀합니다.

* **개선 사항**
  * 냉장고 선택 시트의 UI 스타일 및 아이콘 동작 개선
  * 정렬 및 필터 모달의 애니메이션 동작 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->