### PR TITLE
Feat: 알림 권한 안내 모달 및 1회 노출 게이트 추가

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,6 +16,7 @@ import { useAppHydration } from "@/shared/hooks/useAppHydration";
 import { queryClient } from "@/shared/lib/queryClient";
 import { OnboardingGate } from "@/shared/providers/OnboardingProvider";
 import { SessionProvider } from "@/shared/providers/SessionProvider";
+import { NotificationPermissionGate } from "@/shared/components/NotificationPermissionGate";
 import { useReactQueryDevTools } from "@dev-plugins/react-query";
 import { useFonts } from "expo-font";
 import config from "../tamagui.config";
@@ -90,6 +91,7 @@ export default function RootLayout() {
         <SafeAreaProvider>
           <TamaguiProvider config={config} defaultTheme={resolvedTheme}>
             <OnboardingGate />
+            <NotificationPermissionGate enabled={isAppReady && !shouldShowSplash} />
             {/* 세션 관리 로직을 위해 스택 위에 배치 */}
             <SessionProvider />
 

--- a/src/shared/components/NotificationPermissionGate.tsx
+++ b/src/shared/components/NotificationPermissionGate.tsx
@@ -4,11 +4,13 @@ import * as Notifications from "expo-notifications";
 import { useSegments } from "expo-router";
 import { useEffect, useRef } from "react";
 
-const STORAGE_KEY = "notification_permission_prompted";
+// 키를 바꾸면 기존 사용자에게 다시 노출될 수 있어 versioned key 유지
+const STORAGE_KEY = "notification_permission_prompted_v1";
 
 export function NotificationPermissionGate({ enabled }: { enabled: boolean }) {
   const segments = useSegments();
   const sessionCheckedRef = useRef(false);
+  const sessionRunningRef = useRef(false); //동시 실행 방지용
 
   useEffect(() => {
     if (!enabled) return;
@@ -16,24 +18,26 @@ export function NotificationPermissionGate({ enabled }: { enabled: boolean }) {
     const inOnboarding = currentRootSegment === "onboarding";
     if (inOnboarding) return;
     if (sessionCheckedRef.current) return;
-    sessionCheckedRef.current = true;
+    if (sessionRunningRef.current) return; //이미 진행중이면 스킵
+    sessionRunningRef.current = true;
 
     let cancelled = false;
     (async () => {
       try {
         const completed = await getOnboardingCompleted();
+        if (cancelled) return;
         if (!completed) return;
 
         const prompted = await AsyncStorage.getItem(STORAGE_KEY);
+        if (cancelled) return;
         if (prompted === "1") return;
 
         const perm = await Notifications.getPermissionsAsync();
+        if (cancelled) return;
         if (perm.granted) {
           await AsyncStorage.setItem(STORAGE_KEY, "1");
           return;
         }
-
-        if (cancelled) return;
 
         if (perm.canAskAgain === false) {
           await AsyncStorage.setItem(STORAGE_KEY, "1");
@@ -44,6 +48,9 @@ export function NotificationPermissionGate({ enabled }: { enabled: boolean }) {
         await AsyncStorage.setItem(STORAGE_KEY, "1");
       } catch {
         // 실패 시에는 사용자 경험을 위해 조용히 스킵
+      } finally {
+        sessionCheckedRef.current = true;
+        sessionRunningRef.current = false;
       }
     })();
 

--- a/src/shared/components/NotificationPermissionGate.tsx
+++ b/src/shared/components/NotificationPermissionGate.tsx
@@ -1,0 +1,56 @@
+import { getOnboardingCompleted } from "@/shared/lib/onboarding/onboardingStorage";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Notifications from "expo-notifications";
+import { useSegments } from "expo-router";
+import { useEffect, useRef } from "react";
+
+const STORAGE_KEY = "notification_permission_prompted";
+
+export function NotificationPermissionGate({ enabled }: { enabled: boolean }) {
+  const segments = useSegments();
+  const sessionCheckedRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const currentRootSegment = String(segments?.[0] ?? "");
+    const inOnboarding = currentRootSegment === "onboarding";
+    if (inOnboarding) return;
+    if (sessionCheckedRef.current) return;
+    sessionCheckedRef.current = true;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const completed = await getOnboardingCompleted();
+        if (!completed) return;
+
+        const prompted = await AsyncStorage.getItem(STORAGE_KEY);
+        if (prompted === "1") return;
+
+        const perm = await Notifications.getPermissionsAsync();
+        if (perm.granted) {
+          await AsyncStorage.setItem(STORAGE_KEY, "1");
+          return;
+        }
+
+        if (cancelled) return;
+
+        if (perm.canAskAgain === false) {
+          await AsyncStorage.setItem(STORAGE_KEY, "1");
+          return;
+        }
+
+        await Notifications.requestPermissionsAsync();
+        await AsyncStorage.setItem(STORAGE_KEY, "1");
+      } catch {
+        // 실패 시에는 사용자 경험을 위해 조용히 스킵
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, segments]);
+
+  return null;
+}


### PR DESCRIPTION
## 작업 내용

- 온보딩 완료 후 + 최초 1회만 알림 권한 안내 모달을 띄우는 NotificationPermissionGate 추가

## 연관 이슈

- #143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* 온보딩 완료 후 사용자에게 알림 권한을 요청하는 기능이 추가되었습니다. 요청은 온보딩 중에는 실행되지 않으며 세션당 한 번만 시도되어 중복을 방지합니다.
* 이미 허용되었거나 재요청이 불가한 경우 요청을 건너뛰고, 오류 발생 시 조용히 처리되어 사용자 경험에 영향이 최소화됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->