### PR TITLE
Fix: 앱 테마 변경 시 캘린더 UI가 갱신되지 않는 문제 수정

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,7 +7,7 @@ import { StyleSheet, View } from "react-native";
 import "react-native-reanimated";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import Toast from "react-native-toast-message";
-import { TamaguiProvider } from "tamagui";
+import { TamaguiProvider, Theme } from "tamagui";
 
 import { useIsLoggedIn } from "@/features/auth/store/useAuthStore";
 import FridgeSplashScreen from "@/shared/components/FridgeSplashScreen";
@@ -90,6 +90,7 @@ export default function RootLayout() {
       <QueryClientProvider client={queryClient}>
         <SafeAreaProvider>
           <TamaguiProvider config={config} defaultTheme={resolvedTheme}>
+            <Theme name={resolvedTheme}>
             <OnboardingGate />
             <NotificationPermissionGate enabled={isAppReady && !shouldShowSplash} />
             {/* 세션 관리 로직을 위해 스택 위에 배치 */}
@@ -117,6 +118,7 @@ export default function RootLayout() {
             )}
             <StatusBar style="auto" />
             <Toast config={toastConfig} />
+            </Theme>
           </TamaguiProvider>
         </SafeAreaProvider>
       </QueryClientProvider>

--- a/src/features/calendar/components/CalendarMonthView.tsx
+++ b/src/features/calendar/components/CalendarMonthView.tsx
@@ -2,15 +2,14 @@ import { getCalendarTheme } from "@/features/calendar/constants/calendarTheme";
 import { CalendarMonthYearPickerModal } from "@/features/calendar/components/CalendarMonthYearPickerModal";
 import { daysInMonth, pad2 } from "@/features/calendar/utils/calendar";
 import { fs, ms, rv, s } from "@/shared/constants/layout";
-import { resolveTheme, useThemeStore } from "@/shared/stores/useThemeStore";
+import { useResolvedTheme } from "@/shared/hooks/useResolvedTheme";
 import { ChevronLeft, ChevronRight } from "@tamagui/lucide-icons";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import {
   Pressable,
   Text as RNText,
   View as RNView,
   StyleSheet,
-  useColorScheme,
 } from "react-native";
 import { Calendar, DateData } from "react-native-calendars";
 import { View } from "tamagui";
@@ -21,15 +20,16 @@ export function CalendarMonthView({
   markedDates,
   onSelectDate,
 }: CalendarMonthViewProps) {
-  const theme = useThemeStore((state) => state.theme);
-  const systemColorScheme = useColorScheme();
-  const resolvedTheme = resolveTheme(theme, systemColorScheme);
-  const isDark = resolvedTheme === "dark";
-  const arrowColor = isDark ? "#E5EBE9" : "#111111";
-  const selectedDayBg = isDark ? "#26D19B" : "#2EE6A8";
-  const dayTextColor = isDark ? "#E5EBE9" : "#111111";
-  const selectedDayTextColor = "#111111";
-  const disabledDayTextColor = isDark ? "#4A5A56" : "#D0D4D3";
+  const { resolvedTheme, isDark } = useResolvedTheme();
+  const calendarTheme = useMemo(
+    () => getCalendarTheme(resolvedTheme),
+    [resolvedTheme],
+  );
+  const arrowColor = calendarTheme.arrowColor;
+  const selectedDayBg = calendarTheme.selectedDayBackgroundColor;
+  const dayTextColor = calendarTheme.dayTextColor;
+  const selectedDayTextColor = calendarTheme.selectedDayTextColor;
+  const disabledDayTextColor = calendarTheme.textDisabledColor;
 
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerSeed, setPickerSeed] = useState({ y: 0, m: 1 });
@@ -57,22 +57,25 @@ export function CalendarMonthView({
   );
 
   return (
-    <View px="$2">
+    <View
+      px="$2"
+      style={{ backgroundColor: calendarTheme.calendarBackground }}
+    >
       <Calendar
-        key={jumpKey}
+        key={`${resolvedTheme}-${jumpKey}`}
         current={selectedDate}
         onDayPress={(day: DateData) => onSelectDate(day.dateString)}
         markingType="multi-dot"
         markedDates={markedDates}
-        theme={getCalendarTheme(resolvedTheme)}
+        theme={calendarTheme}
         hideExtraDays={false}
         enableSwipeMonths
         renderArrow={(direction) => (
           <RNText style={[styles.arrow, { color: arrowColor }]}>
             {direction === "left" ? (
-              <ChevronLeft size={s(22)} color="$mainText" />
+              <ChevronLeft size={s(22)} color={arrowColor} />
             ) : (
-              <ChevronRight size={s(22)} color="$mainText" />
+              <ChevronRight size={s(22)} color={arrowColor} />
             )}
           </RNText>
         )}

--- a/src/features/calendar/components/CalendarMonthYearPickerModal.tsx
+++ b/src/features/calendar/components/CalendarMonthYearPickerModal.tsx
@@ -1,4 +1,5 @@
 import { fs, ms, rv } from "@/shared/constants/layout";
+import { useResolvedTheme } from "@/shared/hooks/useResolvedTheme";
 import React, { useEffect, useMemo, useState } from "react";
 import {
   Modal,
@@ -29,8 +30,14 @@ export function CalendarMonthYearPickerModal({
   onClose,
   onConfirm,
 }: CalendarMonthYearPickerModalProps) {
+  const { isDark } = useResolvedTheme();
   const [draftYear, setDraftYear] = useState(year);
   const [draftMonth, setDraftMonth] = useState(month);
+
+  const chipBg = isDark ? "#1A2422" : "#F3F4F6";
+  const chipText = isDark ? "#C5D0CD" : "#374151";
+  const chipActiveBg = isDark ? "#26D19B" : "#2BEEAD";
+  const chipActiveText = isDark ? "#111816" : "#065F46";
 
   useEffect(() => {
     if (open) {
@@ -101,12 +108,17 @@ export function CalendarMonthYearPickerModal({
                   <Pressable
                     key={y}
                     onPress={() => setDraftYear(y)}
-                    style={[styles.yearChip, active && styles.yearChipActive]}
+                    style={[
+                      styles.yearChip,
+                      { backgroundColor: chipBg },
+                      active && { backgroundColor: chipActiveBg },
+                    ]}
                   >
                     <RNText
                       style={[
                         styles.yearChipText,
-                        active && styles.yearChipTextActive,
+                        { color: chipText },
+                        active && { color: chipActiveText, fontWeight: "700" },
                       ]}
                     >
                       {y}
@@ -130,12 +142,17 @@ export function CalendarMonthYearPickerModal({
                   <Pressable
                     key={m}
                     onPress={() => setDraftMonth(m)}
-                    style={[styles.monthCell, active && styles.monthCellActive]}
+                    style={[
+                      styles.monthCell,
+                      { backgroundColor: chipBg },
+                      active && { backgroundColor: chipActiveBg },
+                    ]}
                   >
                     <RNText
                       style={[
                         styles.monthCellText,
-                        active && styles.monthCellTextActive,
+                        { color: chipText },
+                        active && { color: chipActiveText, fontWeight: "700" },
                       ]}
                     >
                       {m}월
@@ -188,21 +205,12 @@ const styles = StyleSheet.create({
     paddingHorizontal: ms(16),
     paddingVertical: ms(10),
     borderRadius: ms(12),
-    backgroundColor: "#F3F4F6",
     minWidth: ms(72),
     alignItems: "center",
-  },
-  yearChipActive: {
-    backgroundColor: "#2BEEAD",
   },
   yearChipText: {
     fontFamily: "BMJUA",
     fontSize: rv({ sm: fs(15), md: fs(16), lg: fs(16) }),
-    color: "#374151",
-  },
-  yearChipTextActive: {
-    color: "#065F46",
-    fontWeight: "700",
   },
   monthGrid: {
     flexDirection: "row",
@@ -214,19 +222,10 @@ const styles = StyleSheet.create({
     width: "22%",
     paddingVertical: ms(10),
     borderRadius: ms(12),
-    backgroundColor: "#F3F4F6",
     alignItems: "center",
-  },
-  monthCellActive: {
-    backgroundColor: "#2BEEAD",
   },
   monthCellText: {
     fontFamily: "BMJUA",
     fontSize: rv({ sm: fs(14), md: fs(15), lg: fs(15) }),
-    color: "#374151",
-  },
-  monthCellTextActive: {
-    color: "#065F46",
-    fontWeight: "700",
   },
 });

--- a/src/shared/hooks/useResolvedTheme.ts
+++ b/src/shared/hooks/useResolvedTheme.ts
@@ -1,0 +1,14 @@
+import { resolveTheme, useThemeStore } from "@/shared/stores/useThemeStore";
+import { useColorScheme } from "react-native";
+
+export function useResolvedTheme() {
+  const theme = useThemeStore((state) => state.theme);
+  const systemColorScheme = useColorScheme();
+  const resolvedTheme = resolveTheme(theme, systemColorScheme);
+
+  return {
+    theme,
+    resolvedTheme,
+    isDark: resolvedTheme === "dark",
+  };
+}


### PR DESCRIPTION
## 작업 내용

- react-native-calendars가 theme을 마운트 시점에만 캐시해 탭 전환·테마 변경 후에도 라이트 스타일이 남던 문제를 해결
- Calendar key에 resolvedTheme을 포함해 리마운트하고, 연·월 피커·Tamagui Theme 래퍼도 앱 테마를 따르도록 맞춤

## 연관 이슈

- #145 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced theme system for improved consistency across the app in dark and light modes.

* **Bug Fixes**
  * Fixed calendar components to properly refresh and reflect theme changes when switching between dark and light modes.

* **Refactor**
  * Optimized theme resolution and application throughout the app for better performance and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fridgely/Front-End/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->