### PR TITLE
Feat: 로그인·회원가입 키보드 제출 UX 개선

### DIFF
--- a/src/features/auth/screens/LoginScreen.tsx
+++ b/src/features/auth/screens/LoginScreen.tsx
@@ -59,6 +59,7 @@ export function LoginScreen() {
         resetScrollToCoords={{ x: 0, y: 0 }}
         scrollEnabled={true}
         enableOnAndroid={true}
+        keyboardShouldPersistTaps="handled"
         extraScrollHeight={rv({ sm: ms(12), md: ms(20), lg: ms(20) })}
       >
         <YStack
@@ -116,6 +117,9 @@ export function LoginScreen() {
               control={control}
               placeholder="비밀번호를 입력하세요."
               secureTextEntry
+              returnKeyType="go"
+              blurOnSubmit
+              onSubmitEditing={handleSubmit(handleLoginClick)}
               rules={{
                 required: "비밀번호를 입력해주세요.",
                 pattern: {

--- a/src/features/auth/screens/SignupScreen.tsx
+++ b/src/features/auth/screens/SignupScreen.tsx
@@ -147,6 +147,9 @@ export function SignupScreen() {
               control={control}
               placeholder="비밀번호를 다시 입력하세요."
               secureTextEntry
+              returnKeyType="go"
+              blurOnSubmit
+              onSubmitEditing={handleSubmit(onSignUpClick)}
               rules={{
                 required: "비밀번호를 다시 입력해주세요.",
                 validate: (value: string) => {

--- a/src/features/auth/types/auth.types.ts
+++ b/src/features/auth/types/auth.types.ts
@@ -16,6 +16,9 @@ interface AuthInputProps {
   secureTextEntry?: boolean;
   autoCapitalize?: "none" | "sentences" | "words" | "characters";
   autoCorrect?: boolean;
+  returnKeyType?: "done" | "go" | "next" | "search" | "send";
+  blurOnSubmit?: boolean;
+  onSubmitEditing?: () => void;
   /**
    * 키보드 기본 default
    * email-address @와.버튼 포함


### PR DESCRIPTION
## 작업 내용

| Before | After |
|--------|--------|
| 로그인하기 1탭 → 키보드만 닫힘 | 1탭 → 바로 로그인/가입 요청 |
| 완료 키 → 키보드만 닫힘 (로그인) | 완료 키 → 제출 (유효할 때) |

## 연관 이슈

- #151 
