### PR TITLE
Feat: 식품 등록·수정 수량 소수 입력 및 단위별 증감 지원

### DIFF
--- a/src/features/food-add/__tests__/utils/quantityInput.test.ts
+++ b/src/features/food-add/__tests__/utils/quantityInput.test.ts
@@ -1,0 +1,77 @@
+import {
+  adjustQuantity,
+  formatQuantityDisplay,
+  getQuantityStep,
+  normalizeQuantity,
+  parseQuantityInput,
+  sanitizeDecimalInput,
+} from "../../utils/quantityInput";
+
+describe("quantityInput", () => {
+  describe("sanitizeDecimalInput", () => {
+    it("숫자와 소수점만 허용한다", () => {
+      expect(sanitizeDecimalInput("1.5kg")).toBe("1.5");
+      expect(sanitizeDecimalInput("12")).toBe("12");
+    });
+
+    it("소수점은 하나만 허용하고 소수 둘째 자리까지만 허용한다", () => {
+      expect(sanitizeDecimalInput("1.234")).toBe("1.23");
+      expect(sanitizeDecimalInput("1..2")).toBe("1.2");
+    });
+
+    it("입력 중인 소수점 문자열을 유지한다", () => {
+      expect(sanitizeDecimalInput("1.")).toBe("1.");
+    });
+  });
+
+  describe("parseQuantityInput", () => {
+    it("유효한 숫자 문자열을 파싱한다", () => {
+      expect(parseQuantityInput("1.5")).toBe(1.5);
+    });
+
+    it("빈 값이나 소수점만 있으면 null을 반환한다", () => {
+      expect(parseQuantityInput("")).toBeNull();
+      expect(parseQuantityInput(".")).toBeNull();
+    });
+  });
+
+  describe("normalizeQuantity", () => {
+    it("최소 수량 미만이면 최소값으로 보정한다", () => {
+      expect(normalizeQuantity(0)).toBe(0.01);
+    });
+
+    it("소수 둘째 자리까지 반올림한다", () => {
+      expect(normalizeQuantity(1.239)).toBe(1.24);
+    });
+  });
+
+  describe("getQuantityStep", () => {
+    it("단위가 개(PIECE)이면 1씩, 그 외에는 0.1씩 조절한다", () => {
+      expect(getQuantityStep("PIECE")).toBe(1);
+      expect(getQuantityStep("L")).toBe(0.1);
+      expect(getQuantityStep("KG")).toBe(0.1);
+    });
+  });
+
+  describe("adjustQuantity", () => {
+    it("개 단위는 정수로 1씩 조절하고 최소 1을 유지한다", () => {
+      expect(adjustQuantity(2, "PIECE", "up")).toBe(3);
+      expect(adjustQuantity(1, "PIECE", "down")).toBe(1);
+    });
+
+    it("그 외 단위는 0.1씩 조절한다", () => {
+      expect(adjustQuantity(1, "L", "up")).toBe(1.1);
+      expect(adjustQuantity(1.1, "KG", "down")).toBe(1);
+    });
+  });
+
+  describe("formatQuantityDisplay", () => {
+    it("정수는 소수점 없이 표시한다", () => {
+      expect(formatQuantityDisplay(2)).toBe("2");
+    });
+
+    it("소수는 불필요한 0을 제거하지 않고 표시한다", () => {
+      expect(formatQuantityDisplay(1.5)).toBe("1.5");
+    });
+  });
+});

--- a/src/features/food-add/__tests__/utils/quantityInput.test.ts
+++ b/src/features/food-add/__tests__/utils/quantityInput.test.ts
@@ -2,9 +2,11 @@ import {
   adjustQuantity,
   formatQuantityDisplay,
   getQuantityStep,
+  isQuantityValid,
   normalizeQuantity,
   parseQuantityInput,
   sanitizeDecimalInput,
+  sanitizeQuantityInput,
 } from "../../utils/quantityInput";
 
 describe("quantityInput", () => {
@@ -35,13 +37,39 @@ describe("quantityInput", () => {
     });
   });
 
+  describe("sanitizeQuantityInput", () => {
+    it("개 단위는 정수만 허용한다", () => {
+      expect(sanitizeQuantityInput("1.5", "PIECE")).toBe("1");
+      expect(sanitizeQuantityInput("2", "PIECE")).toBe("2");
+    });
+  });
+
   describe("normalizeQuantity", () => {
     it("최소 수량 미만이면 최소값으로 보정한다", () => {
       expect(normalizeQuantity(0)).toBe(0.01);
+      expect(normalizeQuantity(0, "PIECE")).toBe(1);
     });
 
     it("소수 둘째 자리까지 반올림한다", () => {
       expect(normalizeQuantity(1.239)).toBe(1.24);
+    });
+
+    it("개 단위는 정수로 반올림하고 최소 1을 유지한다", () => {
+      expect(normalizeQuantity(1.6, "PIECE")).toBe(2);
+      expect(normalizeQuantity(0.2, "PIECE")).toBe(1);
+    });
+  });
+
+  describe("isQuantityValid", () => {
+    it("개 단위는 1 이상의 정수만 유효하다", () => {
+      expect(isQuantityValid(2, "PIECE")).toBe(true);
+      expect(isQuantityValid(1.5, "PIECE")).toBe(false);
+      expect(isQuantityValid(0, "PIECE")).toBe(false);
+    });
+
+    it("그 외 단위는 최소 수량 이상이면 유효하다", () => {
+      expect(isQuantityValid(0.5, "L")).toBe(true);
+      expect(isQuantityValid(0, "L")).toBe(false);
     });
   });
 

--- a/src/features/food-add/components/QuantityInput/QuantityInput.tsx
+++ b/src/features/food-add/components/QuantityInput/QuantityInput.tsx
@@ -1,9 +1,18 @@
 import { Minus, Plus } from "@tamagui/lucide-icons";
-import React from "react";
-import { Controller } from "react-hook-form";
+import React, { useState } from "react";
+import { Controller, useWatch } from "react-hook-form";
 import { Keyboard } from "react-native";
 import { Button, Input, Text, XStack, styled } from "tamagui";
 import { QuantityInputProps } from "../../types";
+import {
+  MIN_QUANTITY,
+  adjustQuantity,
+  formatQuantityDisplay,
+  isQuantityValid,
+  normalizeQuantity,
+  parseQuantityInput,
+  sanitizeDecimalInput,
+} from "../../utils/quantityInput";
 import { UnitSelector } from "./UnitSelector";
 import { fs, ms, s } from "@/shared/constants/layout";
 
@@ -13,22 +22,15 @@ const LabelText = styled(Text, {
   fontWeight: "700",
 });
 
-const MIN_QUANTITY = 1;
-
-const normalizeQuantity = (value: number | null | undefined) => {
-  const numericValue = Number(value ?? MIN_QUANTITY);
-
-  if (!Number.isFinite(numericValue)) {
-    return MIN_QUANTITY;
-  }
-
-  return Math.max(MIN_QUANTITY, numericValue);
-};
-
 export const QuantityInput = ({
   control,
   onInputFocus,
 }: QuantityInputProps) => {
+  const [editingAmountText, setEditingAmountText] = useState<string | null>(
+    null,
+  );
+  const unit = useWatch({ control, name: "unit" }) ?? "PIECE";
+
   return (
     <XStack ai="center" jc="space-between">
       <LabelText fontFamily="$baemin" fontSize={fs(14)}>
@@ -43,66 +45,85 @@ export const QuantityInput = ({
             rules={{
               required: "수량을 입력해주세요.",
               validate: (value) =>
-                value >= MIN_QUANTITY || "수량은 1 이상이어야 합니다.",
+                isQuantityValid(value) ||
+                `수량은 ${MIN_QUANTITY} 이상이어야 합니다.`,
             }}
-            render={({ field: { onChange, value } }) => (
-              <>
-                <Button
-                  w={ms(20)}
-                  h={ms(26)}
-                  br="$2"
-                  bg="$surface"
-                  icon={<Minus size={s(14)} />}
-                  onPress={() => {
-                    const next = normalizeQuantity(value) - 1;
-                    onChange(normalizeQuantity(next));
-                  }}
-                />
-                <Input
-                  w={ms(46)}
-                  h={ms(28)}
-                  p={0}
-                  ta="center"
-                  fontFamily="$baemin"
-                  fontSize={fs(14)}
-                  fontWeight="700"
-                  keyboardType="number-pad"
-                  returnKeyType="done"
-                  selectTextOnFocus
-                  borderWidth={0}
-                  backgroundColor="transparent"
-                  value={String(normalizeQuantity(value))}
-                  onChangeText={(text) => {
-                    const onlyNumbers = text.replace(/[^0-9]/g, "");
+            render={({ field: { onChange, value } }) => {
+              const normalizedValue = normalizeQuantity(value);
+              const displayValue =
+                editingAmountText ?? formatQuantityDisplay(normalizedValue);
 
-                    if (onlyNumbers.length === 0) {
-                      return;
-                    }
+              const commitAmount = (text: string) => {
+                const parsed = parseQuantityInput(text);
+                const next = normalizeQuantity(parsed);
+                onChange(next);
+                setEditingAmountText(null);
+              };
 
-                    const nextValue = Number(onlyNumbers);
-                    if (!Number.isFinite(nextValue)) {
-                      return;
-                    }
+              return (
+                <>
+                  <Button
+                    w={ms(20)}
+                    h={ms(26)}
+                    br="$2"
+                    bg="$surface"
+                    icon={<Minus size={s(14)} />}
+                    onPress={() => {
+                      setEditingAmountText(null);
+                      onChange(
+                        adjustQuantity(normalizedValue, unit, "down"),
+                      );
+                    }}
+                  />
+                  <Input
+                    w={ms(56)}
+                    h={ms(28)}
+                    p={0}
+                    ta="center"
+                    fontFamily="$baemin"
+                    fontSize={fs(14)}
+                    fontWeight="700"
+                    keyboardType="decimal-pad"
+                    returnKeyType="done"
+                    selectTextOnFocus
+                    borderWidth={0}
+                    backgroundColor="transparent"
+                    value={displayValue}
+                    onChangeText={(text) => {
+                      const sanitized = sanitizeDecimalInput(text);
+                      setEditingAmountText(sanitized);
 
-                    onChange(normalizeQuantity(nextValue));
-                  }}
-                  onBlur={() => onChange(normalizeQuantity(value))}
-                  onFocus={onInputFocus}
-                  onSubmitEditing={() => Keyboard.dismiss()}
-                />
-                <Button
-                  w={ms(20)}
-                  h={ms(26)}
-                  br="$2"
-                  bg="$surface"
-                  icon={<Plus size={s(14)} />}
-                  onPress={() => {
-                    const next = normalizeQuantity(value) + 1;
-                    onChange(normalizeQuantity(next));
-                  }}
-                />
-              </>
-            )}
+                      const parsed = parseQuantityInput(sanitized);
+                      if (parsed !== null && !sanitized.endsWith(".")) {
+                        onChange(normalizeQuantity(parsed));
+                      }
+                    }}
+                    onBlur={() => commitAmount(displayValue)}
+                    onFocus={() => {
+                      setEditingAmountText(
+                        formatQuantityDisplay(normalizedValue),
+                      );
+                      onInputFocus?.();
+                    }}
+                    onSubmitEditing={() => {
+                      commitAmount(displayValue);
+                      Keyboard.dismiss();
+                    }}
+                  />
+                  <Button
+                    w={ms(20)}
+                    h={ms(26)}
+                    br="$2"
+                    bg="$surface"
+                    icon={<Plus size={s(14)} />}
+                    onPress={() => {
+                      setEditingAmountText(null);
+                      onChange(adjustQuantity(normalizedValue, unit, "up"));
+                    }}
+                  />
+                </>
+              );
+            }}
           />
         </XStack>
 

--- a/src/features/food-add/components/QuantityInput/QuantityInput.tsx
+++ b/src/features/food-add/components/QuantityInput/QuantityInput.tsx
@@ -5,13 +5,13 @@ import { Keyboard } from "react-native";
 import { Button, Input, Text, XStack, styled } from "tamagui";
 import { QuantityInputProps } from "../../types";
 import {
-  MIN_QUANTITY,
   adjustQuantity,
   formatQuantityDisplay,
+  getQuantityValidationMessage,
   isQuantityValid,
   normalizeQuantity,
   parseQuantityInput,
-  sanitizeDecimalInput,
+  sanitizeQuantityInput,
 } from "../../utils/quantityInput";
 import { UnitSelector } from "./UnitSelector";
 import { fs, ms, s } from "@/shared/constants/layout";
@@ -30,6 +30,8 @@ export const QuantityInput = ({
     null,
   );
   const unit = useWatch({ control, name: "unit" }) ?? "PIECE";
+  const amount = useWatch({ control, name: "amount" });
+  const amountOnChangeRef = React.useRef<(value: number) => void>(() => {});
 
   return (
     <XStack ai="center" jc="space-between">
@@ -45,17 +47,18 @@ export const QuantityInput = ({
             rules={{
               required: "수량을 입력해주세요.",
               validate: (value) =>
-                isQuantityValid(value) ||
-                `수량은 ${MIN_QUANTITY} 이상이어야 합니다.`,
+                isQuantityValid(value, unit) || getQuantityValidationMessage(unit),
             }}
             render={({ field: { onChange, value } }) => {
-              const normalizedValue = normalizeQuantity(value);
+              amountOnChangeRef.current = onChange;
+              const normalizedValue = normalizeQuantity(value, unit);
               const displayValue =
-                editingAmountText ?? formatQuantityDisplay(normalizedValue);
+                editingAmountText ??
+                formatQuantityDisplay(normalizedValue, unit);
 
               const commitAmount = (text: string) => {
                 const parsed = parseQuantityInput(text);
-                const next = normalizeQuantity(parsed);
+                const next = normalizeQuantity(parsed, unit);
                 onChange(next);
                 setEditingAmountText(null);
               };
@@ -90,18 +93,18 @@ export const QuantityInput = ({
                     backgroundColor="transparent"
                     value={displayValue}
                     onChangeText={(text) => {
-                      const sanitized = sanitizeDecimalInput(text);
+                      const sanitized = sanitizeQuantityInput(text, unit);
                       setEditingAmountText(sanitized);
 
                       const parsed = parseQuantityInput(sanitized);
                       if (parsed !== null && !sanitized.endsWith(".")) {
-                        onChange(normalizeQuantity(parsed));
+                        onChange(normalizeQuantity(parsed, unit));
                       }
                     }}
                     onBlur={() => commitAmount(displayValue)}
                     onFocus={() => {
                       setEditingAmountText(
-                        formatQuantityDisplay(normalizedValue),
+                        formatQuantityDisplay(normalizedValue, unit),
                       );
                       onInputFocus?.();
                     }}
@@ -132,7 +135,18 @@ export const QuantityInput = ({
           name="unit"
           rules={{ required: "단위를 선택해주세요." }}
           render={({ field: { value, onChange } }) => (
-            <UnitSelector value={value} onChange={onChange} />
+            <UnitSelector
+              value={value}
+              onChange={(nextUnit: string) => {
+                onChange(nextUnit);
+                if (amount != null) {
+                  setEditingAmountText(null);
+                  amountOnChangeRef.current(
+                    normalizeQuantity(amount, nextUnit),
+                  );
+                }
+              }}
+            />
           )}
         />
       </XStack>

--- a/src/features/food-add/utils/quantityInput.ts
+++ b/src/features/food-add/utils/quantityInput.ts
@@ -1,0 +1,87 @@
+const MIN_QUANTITY = 0.01;
+const MIN_PIECE_QUANTITY = 1;
+const MAX_DECIMAL_PLACES = 2;
+const DECIMAL_QUANTITY_STEP = 0.1;
+const PIECE_UNIT = "PIECE";
+
+const getQuantityStep = (unit: string): number =>
+  unit === PIECE_UNIT ? 1 : DECIMAL_QUANTITY_STEP;
+
+const adjustQuantity = (
+  value: number,
+  unit: string,
+  direction: "up" | "down",
+): number => {
+  const step = getQuantityStep(unit);
+  const delta = direction === "up" ? step : -step;
+
+  if (unit === PIECE_UNIT) {
+    const next = Math.round(value + delta);
+    return Math.max(MIN_PIECE_QUANTITY, next);
+  }
+
+  return normalizeQuantity(value + delta);
+};
+
+const sanitizeDecimalInput = (text: string): string => {
+  let cleaned = text.replace(/,/g, ".").replace(/[^0-9.]/g, "");
+  const dotIndex = cleaned.indexOf(".");
+
+  if (dotIndex === -1) {
+    return cleaned;
+  }
+
+  const intPart = cleaned.slice(0, dotIndex);
+  const decPart = cleaned
+    .slice(dotIndex + 1)
+    .replace(/\./g, "")
+    .slice(0, MAX_DECIMAL_PLACES);
+
+  if (decPart.length === 0 && !cleaned.endsWith(".")) {
+    return intPart;
+  }
+
+  return `${intPart}.${decPart}`;
+};
+
+const parseQuantityInput = (text: string): number | null => {
+  const trimmed = text.trim();
+  if (!trimmed || trimmed === ".") {
+    return null;
+  }
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const roundQuantity = (value: number): number =>
+  Math.round(value * 10 ** MAX_DECIMAL_PLACES) / 10 ** MAX_DECIMAL_PLACES;
+
+const normalizeQuantity = (value: number | null | undefined): number => {
+  const numericValue = value ?? MIN_QUANTITY;
+
+  if (!Number.isFinite(numericValue)) {
+    return MIN_QUANTITY;
+  }
+
+  return Math.max(MIN_QUANTITY, roundQuantity(numericValue));
+};
+
+const formatQuantityDisplay = (value: number): string => {
+  const rounded = roundQuantity(value);
+  return Number.isInteger(rounded) ? String(rounded) : String(rounded);
+};
+
+const isQuantityValid = (value: number): boolean => value >= MIN_QUANTITY;
+
+export {
+  MIN_QUANTITY,
+  PIECE_UNIT,
+  adjustQuantity,
+  formatQuantityDisplay,
+  getQuantityStep,
+  isQuantityValid,
+  normalizeQuantity,
+  parseQuantityInput,
+  sanitizeDecimalInput,
+};

--- a/src/features/food-add/utils/quantityInput.ts
+++ b/src/features/food-add/utils/quantityInput.ts
@@ -20,7 +20,7 @@ const adjustQuantity = (
     return Math.max(MIN_PIECE_QUANTITY, next);
   }
 
-  return normalizeQuantity(value + delta);
+  return normalizeQuantity(value + delta, unit);
 };
 
 const sanitizeDecimalInput = (text: string): string => {
@@ -44,6 +44,14 @@ const sanitizeDecimalInput = (text: string): string => {
   return `${intPart}.${decPart}`;
 };
 
+const sanitizeQuantityInput = (text: string, unit: string): string => {
+  if (unit !== PIECE_UNIT) {
+    return sanitizeDecimalInput(text);
+  }
+
+  return text.replace(/,/g, ".").split(".")[0].replace(/[^0-9]/g, "");
+};
+
 const parseQuantityInput = (text: string): number | null => {
   const trimmed = text.trim();
   if (!trimmed || trimmed === ".") {
@@ -57,31 +65,52 @@ const parseQuantityInput = (text: string): number | null => {
 const roundQuantity = (value: number): number =>
   Math.round(value * 10 ** MAX_DECIMAL_PLACES) / 10 ** MAX_DECIMAL_PLACES;
 
-const normalizeQuantity = (value: number | null | undefined): number => {
-  const numericValue = value ?? MIN_QUANTITY;
+const normalizeQuantity = (
+  value: number | null | undefined,
+  unit?: string,
+): number => {
+  if (!Number.isFinite(value ?? NaN)) {
+    return unit === PIECE_UNIT ? MIN_PIECE_QUANTITY : MIN_QUANTITY;
+  }
 
-  if (!Number.isFinite(numericValue)) {
-    return MIN_QUANTITY;
+  const numericValue = value as number;
+
+  if (unit === PIECE_UNIT) {
+    return Math.max(MIN_PIECE_QUANTITY, Math.round(numericValue));
   }
 
   return Math.max(MIN_QUANTITY, roundQuantity(numericValue));
 };
 
-const formatQuantityDisplay = (value: number): string => {
-  const rounded = roundQuantity(value);
-  return Number.isInteger(rounded) ? String(rounded) : String(rounded);
+const formatQuantityDisplay = (value: number, unit?: string): string => {
+  const normalized = normalizeQuantity(value, unit);
+  return String(normalized);
 };
 
-const isQuantityValid = (value: number): boolean => value >= MIN_QUANTITY;
+const isQuantityValid = (value: number, unit?: string): boolean => {
+  if (unit === PIECE_UNIT) {
+    return Number.isInteger(value) && value >= MIN_PIECE_QUANTITY;
+  }
+
+  return value >= MIN_QUANTITY;
+};
+
+const getQuantityValidationMessage = (unit?: string): string =>
+  unit === PIECE_UNIT
+    ? "수량은 1 이상의 정수여야 합니다."
+    : `수량은 ${MIN_QUANTITY} 이상이어야 합니다.`;
 
 export {
+  MIN_PIECE_QUANTITY,
   MIN_QUANTITY,
   PIECE_UNIT,
   adjustQuantity,
   formatQuantityDisplay,
   getQuantityStep,
+  getQuantityValidationMessage,
   isQuantityValid,
   normalizeQuantity,
   parseQuantityInput,
   sanitizeDecimalInput,
+  sanitizeQuantityInput,
 };


### PR DESCRIPTION
## 작업 내용

- 식품 등록/수정 `QuantityInput`에서 수량 소수점 입력 지원 (`decimal-pad`, 소수 둘째 자리까지)
- `+` / `-` 버튼 단위별 스텝 분기
  - **개(PIECE)**: 1씩 증감, 정수 유지, 최소 1
  - **ml, L, g, kg 등**: 0.1씩 증감
- 입력 중 `"1."` 같은 중간 상태 유지, blur 시 정규화
- 유틸 단위 테스트 추기

## 연관 이슈

- #157


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 수량 입력 유틸리티에 대한 단위 테스트 추가

* **Refactor**
  * 수량 입력 컴포넌트의 입력 처리 및 검증 로직 개선
  * 소수점 입력 지원 강화 (키보드 타입 개선, 자동 정규화)
  * 증감 버튼 동작 최적화 (단위별 스텝 적용)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fridgely/Front-End/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->