### PR TITLE
Fix: 기본 테마 system 유지 + light/dark 토글 및 온보딩 버튼 조정

### DIFF
--- a/src/features/onboarding/screens/OnboardingScreen.tsx
+++ b/src/features/onboarding/screens/OnboardingScreen.tsx
@@ -25,9 +25,9 @@ export function OnboardingScreen() {
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor }}>
       <YStack f={1}>
-        <XStack px="$6" pt="$2" jc="flex-end">
+        <XStack px="$6" pt="$5" jc="flex-end">
           <Button unstyled onPress={toggleTheme}>
-            <Moon size={s(18)} color={isDark ? "#FFFFFF" : "#0B1110"} />
+            <Moon size={s(22)} color={isDark ? "#FFFFFF" : "#0B1110"} />
           </Button>
         </XStack>
 

--- a/src/features/profile/screens/ProfileScreen.tsx
+++ b/src/features/profile/screens/ProfileScreen.tsx
@@ -7,7 +7,7 @@ import {
   rv,
 } from "@/shared/constants/layout";
 import { useImagePickerActions } from "@/shared/hooks/useImagePickerActions";
-import { useThemeStore } from "@/shared/stores/useThemeStore";
+import { resolveTheme, useThemeStore } from "@/shared/stores/useThemeStore";
 import {
   Bell,
   Headphones,
@@ -17,7 +17,7 @@ import {
 } from "@tamagui/lucide-icons";
 import { useRouter } from "expo-router";
 import React, { useEffect, useState } from "react";
-import { Linking } from "react-native";
+import { Linking, useColorScheme } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   Avatar,
@@ -48,8 +48,9 @@ export function ProfileScreen() {
   const router = useRouter();
   const theme = useThemeStore((state) => state.theme);
   const toggleTheme = useThemeStore((state) => state.toggleTheme);
-  const themeLabel =
-    theme === "system" ? "시스템" : theme === "dark" ? "다크" : "라이트";
+  const systemColorScheme = useColorScheme();
+  const resolvedTheme = resolveTheme(theme, systemColorScheme);
+  const themeLabel = resolvedTheme === "dark" ? "다크" : "라이트";
   const { data: allFoodStatusData } = useAllFoodStatusQuery(true);
   const { data: memberProfile } = useMemberProfileQuery();
 

--- a/src/shared/stores/useThemeStore.ts
+++ b/src/shared/stores/useThemeStore.ts
@@ -1,4 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { Appearance } from "react-native";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
@@ -28,14 +29,14 @@ export const useThemeStore = create<ThemeStore>()(
       theme: "system",
       setTheme: (theme: AppTheme) => set({ theme }),
       toggleTheme: () =>
-        set((state) => ({
-          theme:
-            state.theme === "light"
-              ? "dark"
-              : state.theme === "dark"
-                ? "system"
-                : "light",
-        })),
+        set((state) => {
+          // 시스템 인 경우에도 토글은 라이트, 다크로만 전환
+          const systemColorScheme = Appearance.getColorScheme();
+          const resolvedTheme = resolveTheme(state.theme, systemColorScheme);
+          const nextTheme: AppTheme =
+            resolvedTheme === "dark" ? "light" : "dark";
+          return { theme: nextTheme };
+        }),
     }),
     {
       name: "theme-storage",


### PR DESCRIPTION
## 작업 내용

- `useThemeStore.toggleTheme` 수정
  - 저장값 기본은 `system` 유지
  - 다만 토글 동작은 `light <-> dark`만 전환되도록 변경(다시 system으로 돌아가지 않음)
- `ProfileScreen` 테마 라벨 표시 수정
  - 저장된 `theme(system/light/dark)` 값이 아니라 `resolveTheme` 결과(light/dark)로 라벨을 표시
- 온보딩 화면 테마 버튼 UI 개선
  - 상단 여백(`pt`)을 늘려 버튼을 더 띄움
  - 달 아이콘 크기를 소폭 확대

## 연관 이슈

- #159


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **UI 개선**
  * 온보딩 화면의 테마 토글 UI 레이아웃 최적화 및 아이콘 크기 조정

* **기능 개선**
  * 시스템 색상 스킴을 반영하는 테마 감지 로직 강화
  * 테마 토글 동작 개선으로 더 직관적인 사용자 경험 제공

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fridgely/Front-End/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->