### PR TITLE
Feat: 로그인 화면 아이디 저장 옵션 추가

### DIFF
--- a/src/features/auth/hooks/useAuthMutation.test.tsx
+++ b/src/features/auth/hooks/useAuthMutation.test.tsx
@@ -11,6 +11,10 @@ jest.mock("@/shared/apis/apiClient");
 jest.mock("react-native-toast-message", () => ({ show: jest.fn() }));
 jest.mock("expo-router", () => ({ useRouter: jest.fn() }));
 jest.mock("../store/useAuthStore", () => ({ useAuthActions: jest.fn() }));
+jest.mock("@/shared/lib/loginIdStorage/loginIdStorage", () => ({
+  setLastLoginId: jest.fn(),
+  getRememberLoginIdEnabled: jest.fn(() => Promise.resolve(true)),
+}));
 
 const mockedApiClient = apiClient as jest.MockedFunction<typeof apiClient>;
 
@@ -26,6 +30,9 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 describe("useAuthMutation 테스트", () => {
   const mockReplace = jest.fn();
   const mockSetTokens = jest.fn();
+  const { setLastLoginId } = jest.requireMock(
+    "@/shared/lib/loginIdStorage/loginIdStorage",
+  ) as { setLastLoginId: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -57,6 +64,7 @@ describe("useAuthMutation 테스트", () => {
       // 비동기 로직 완료 대기
       await waitFor(() => {
         expect(mockSetTokens).toHaveBeenCalledWith(successResponse);
+        expect(setLastLoginId).toHaveBeenCalledWith(loginData.loginId);
         expect(Toast.show).toHaveBeenCalledWith(
           expect.objectContaining({
             type: "success",
@@ -81,6 +89,7 @@ describe("useAuthMutation 테스트", () => {
 
       await waitFor(() => {
         expect(mockSetTokens).not.toHaveBeenCalled();
+        expect(setLastLoginId).not.toHaveBeenCalled();
         expect(Toast.show).toHaveBeenCalledWith(
           expect.objectContaining({
             type: "error",

--- a/src/features/auth/hooks/useAuthMutation.ts
+++ b/src/features/auth/hooks/useAuthMutation.ts
@@ -4,15 +4,23 @@ import Toast from "react-native-toast-message";
 import { loginApi, signupApi } from "../api/auth";
 import { LoginRequest, LoginResponse, SignupRequest } from "../api/auth.types";
 import { useAuthActions } from "../store/useAuthStore";
+import {
+  getRememberLoginIdEnabled,
+  setLastLoginId,
+} from "@/shared/lib/loginIdStorage/loginIdStorage";
 
 const useLoginMutation = () => {
   const { setTokens } = useAuthActions();
   const router = useRouter();
 
   return useApiMutation<LoginRequest, LoginResponse>(loginApi, {
-    onSuccess: async (res) => {
+    onSuccess: async (res, variables) => {
       if (res.result === "SUCCESS") {
         await setTokens(res);
+        const rememberEnabled = await getRememberLoginIdEnabled();
+        if (rememberEnabled && variables?.loginId) {
+          await setLastLoginId(variables.loginId);
+        }
         Toast.show({
           type: "success",
           text1: "로그인 성공",

--- a/src/features/auth/hooks/useAuthMutation.ts
+++ b/src/features/auth/hooks/useAuthMutation.ts
@@ -1,13 +1,13 @@
 import { useApiMutation } from "@/shared/apis/builder/ApiBuilder";
+import {
+  getRememberLoginIdEnabled,
+  setLastLoginId,
+} from "@/shared/lib/loginIdStorage/loginIdStorage";
 import { useRouter } from "expo-router";
 import Toast from "react-native-toast-message";
 import { loginApi, signupApi } from "../api/auth";
 import { LoginRequest, LoginResponse, SignupRequest } from "../api/auth.types";
 import { useAuthActions } from "../store/useAuthStore";
-import {
-  getRememberLoginIdEnabled,
-  setLastLoginId,
-} from "@/shared/lib/loginIdStorage/loginIdStorage";
 
 const useLoginMutation = () => {
   const { setTokens } = useAuthActions();
@@ -17,10 +17,12 @@ const useLoginMutation = () => {
     onSuccess: async (res, variables) => {
       if (res.result === "SUCCESS") {
         await setTokens(res);
-        const rememberEnabled = await getRememberLoginIdEnabled();
-        if (rememberEnabled && variables?.loginId) {
-          await setLastLoginId(variables.loginId);
-        }
+        try {
+          const rememberEnabled = await getRememberLoginIdEnabled();
+          if (rememberEnabled && variables?.loginId) {
+            await setLastLoginId(variables.loginId);
+          }
+        } catch {}
         Toast.show({
           type: "success",
           text1: "로그인 성공",

--- a/src/features/auth/screens/LoginScreen.tsx
+++ b/src/features/auth/screens/LoginScreen.tsx
@@ -1,5 +1,6 @@
 import { LogIn } from "@tamagui/lucide-icons";
 import { useRouter } from "expo-router";
+import React, { useEffect, useState } from "react";
 import { useColorScheme } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -8,12 +9,19 @@ import {
   Heading,
   Paragraph,
   Spacer,
+  Switch,
   Text,
   XStack,
   YStack,
 } from "tamagui";
 
 import { fs, ms, rv } from "@/shared/constants/layout";
+import {
+  clearLastLoginId,
+  getLastLoginId,
+  getRememberLoginIdEnabled,
+  setRememberLoginIdEnabled,
+} from "@/shared/lib/loginIdStorage/loginIdStorage";
 import { resolveTheme, useThemeStore } from "@/shared/stores/useThemeStore";
 import { useForm } from "react-hook-form";
 import { AuthInput } from "../components/AuthInput";
@@ -31,6 +39,7 @@ export function LoginScreen() {
     control,
     handleSubmit,
     formState: { isValid },
+    setValue,
   } = useForm<AuthFormData>({
     mode: "onChange",
     defaultValues: {
@@ -38,6 +47,34 @@ export function LoginScreen() {
       password: "",
     },
   });
+
+  const [rememberIdChecked, setRememberIdChecked] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const rememberEnabled = await getRememberLoginIdEnabled();
+        if (!mounted) return;
+        setRememberIdChecked(rememberEnabled);
+        if (!rememberEnabled) {
+          return;
+        }
+        const lastLoginId = await getLastLoginId();
+        if (!mounted) return;
+        if (lastLoginId) {
+          setValue("id", lastLoginId, {
+            shouldDirty: false,
+            shouldValidate: true,
+          });
+        }
+      } catch {}
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, [setValue]);
 
   const handleLoginClick = (data: AuthFormData) => {
     login({
@@ -130,7 +167,34 @@ export function LoginScreen() {
               }}
             />
 
-            <Spacer size="$2" />
+            <XStack jc="flex-start" ai="center">
+              <XStack ai="center" gap="$2">
+                <Switch
+                  size="$3"
+                  checked={rememberIdChecked}
+                  onCheckedChange={async (checked) => {
+                    setRememberIdChecked(checked);
+                    await setRememberLoginIdEnabled(checked);
+                    if (!checked) {
+                      await clearLastLoginId();
+                      setValue("id", "", {
+                        shouldDirty: false,
+                        shouldValidate: true,
+                      });
+                    }
+                  }}
+                  backgroundColor={rememberIdChecked ? "$primary" : "$gray4"}
+                  height={ms(24)}
+                  width={ms(40)}
+                  p={ms(1)}
+                >
+                  <Switch.Thumb size="$3" />
+                </Switch>
+                <Text fontFamily="$baemin" fontWeight="700" color="$gray10">
+                  아이디 저장
+                </Text>
+              </XStack>
+            </XStack>
 
             <Button
               bc="$primary"

--- a/src/features/auth/screens/LoginScreen.tsx
+++ b/src/features/auth/screens/LoginScreen.tsx
@@ -173,14 +173,19 @@ export function LoginScreen() {
                   size="$3"
                   checked={rememberIdChecked}
                   onCheckedChange={async (checked) => {
+                    const prev = rememberIdChecked;
                     setRememberIdChecked(checked);
-                    await setRememberLoginIdEnabled(checked);
-                    if (!checked) {
-                      await clearLastLoginId();
-                      setValue("id", "", {
-                        shouldDirty: false,
-                        shouldValidate: true,
-                      });
+                    try {
+                      await setRememberLoginIdEnabled(checked);
+                      if (!checked) {
+                        await clearLastLoginId();
+                        setValue("id", "", {
+                          shouldDirty: false,
+                          shouldValidate: true,
+                        });
+                      }
+                    } catch {
+                      setRememberIdChecked(prev);
                     }
                   }}
                   backgroundColor={rememberIdChecked ? "$primary" : "$gray4"}

--- a/src/shared/lib/loginIdStorage/loginIdStorage.ts
+++ b/src/shared/lib/loginIdStorage/loginIdStorage.ts
@@ -1,0 +1,27 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const LAST_LOGIN_ID_KEY = "lastLoginId";
+const REMEMBER_LOGIN_ID_KEY = "rememberLoginId";
+
+export async function getLastLoginId(): Promise<string | null> {
+  const value = await AsyncStorage.getItem(LAST_LOGIN_ID_KEY);
+  return value ?? null;
+}
+
+export async function setLastLoginId(loginId: string): Promise<void> {
+  await AsyncStorage.setItem(LAST_LOGIN_ID_KEY, loginId);
+}
+
+export async function clearLastLoginId(): Promise<void> {
+  await AsyncStorage.removeItem(LAST_LOGIN_ID_KEY);
+}
+
+export async function getRememberLoginIdEnabled(): Promise<boolean> {
+  const value = await AsyncStorage.getItem(REMEMBER_LOGIN_ID_KEY);
+  return value === "1";
+}
+
+export async function setRememberLoginIdEnabled(enabled: boolean): Promise<void> {
+  await AsyncStorage.setItem(REMEMBER_LOGIN_ID_KEY, enabled ? "1" : "0");
+}
+


### PR DESCRIPTION
## 작업 내용

- 로그인 화면에 **아이디 저장** 토글 추가 
- `loginIdStorage` 유틸 추가
  - `lastLoginId`: 마지막 로그인 아이디
  - `rememberLoginId`: 저장 옵션 ON/OFF
- 로그인 성공 시 토글이 ON일 때만 `loginId` 저장
- 로그인 화면 진입 시 토글이 ON이면 저장된 아이디 자동 입력
- 토글 OFF 시 저장 아이디 삭제 및 입력란 초기화

## 연관 이슈

- #161


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로그인 성공 시 ID를 저장하는 옵션 추가 및 자동 입력 기능 제공
  * 로그인 화면에서 ID 저장 토글로 설정을 켜고 끌 수 있음

* **테스트**
  * 로그인 성공/실패에 따른 ID 저장 동작을 검증하는 테스트 추가 (저장 호출 여부 확인)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fridgely/Front-End/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->