### PR TITLE
Feat: 마이페이지 앱 버전 표시를 설정값 기반으로 변경

### DIFF
--- a/src/features/profile/screens/ProfileScreen.tsx
+++ b/src/features/profile/screens/ProfileScreen.tsx
@@ -15,6 +15,7 @@ import {
   Palette,
   Refrigerator,
 } from "@tamagui/lucide-icons";
+import Constants from "expo-constants";
 import { useRouter } from "expo-router";
 import React, { useEffect, useState } from "react";
 import { Linking, useColorScheme } from "react-native";
@@ -53,6 +54,11 @@ export function ProfileScreen() {
   const themeLabel = resolvedTheme === "dark" ? "다크" : "라이트";
   const { data: allFoodStatusData } = useAllFoodStatusQuery(true);
   const { data: memberProfile } = useMemberProfileQuery();
+  const appVersion =
+    Constants.expoConfig?.version ??
+    (Constants as any).manifest2?.extra?.expoClient?.version ??
+    (Constants as any).manifest?.version ??
+    "1.0.0";
 
   const registeredFoodCount =
     (allFoodStatusData?.data?.blackCount ?? 0) +
@@ -264,14 +270,16 @@ export function ProfileScreen() {
             <Text
               color="$gray10"
               fontSize={rv({ sm: fs(12), md: fs(13), lg: fs(13) })}
+              fontFamily="$baemin"
             >
               Fridgely App
             </Text>
             <Text
               color="$gray10"
               fontSize={rv({ sm: fs(12), md: fs(13), lg: fs(13) })}
+              fontFamily="$baemin"
             >
-              버전 1.0.0
+              버전 {appVersion}
             </Text>
           </YStack>
         </YStack>


### PR DESCRIPTION
## 작업 내용

- 마이페이지 하단 버전 표기를 expo-constants에서 읽은 값으로 표시
- 런타임별 버전 필드 차이를 고려해 fallback 처리

## 연관 이슈

- #166


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 프로필 화면에서 앱 버전이 정확하게 표시되도록 개선했습니다. 이제 실제 빌드 설정에서 버전 정보를 동적으로 읽어오므로, 표시되는 버전이 설치된 앱의 실제 버전과 일치합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->